### PR TITLE
fix debug format

### DIFF
--- a/flit/install.py
+++ b/flit/install.py
@@ -54,7 +54,7 @@ class Installer(object):
     def __init__(self, ini_path, user=None, symlink=False):
         self.ini_info = inifile.read_pkg_ini(ini_path)
         self.metadata, self.module = common.metadata_and_module_from_ini_path(ini_path)
-        log.debug(user, site.ENABLE_USER_SITE)
+        log.debug('%s, %s',user, site.ENABLE_USER_SITE)
         if user is None:
             self.user = site.ENABLE_USER_SITE
         else:


### PR DESCRIPTION
This still complain for me, it seem to take a format string, like info, warning, message...etc. 