### PR TITLE
Add 'flit develop' command

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -33,7 +33,7 @@ def main(argv=None):
     )
 
     parser_install = subparsers.add_parser('install',
-        help="Install the package directly for development",
+        help="Install the package",
     )
     parser_install.add_argument('--symlink', action='store_true',
         help="Symlink the module/package into site packages instead of copying it"
@@ -42,6 +42,19 @@ def main(argv=None):
         help="Do a user-local install (default if site.ENABLE_USER_SITE is True)"
     )
     parser_install.add_argument('--env', action='store_false', dest='user',
+        help="Install into sys.prefix (default if site.ENABLE_USER_SITE is False, i.e. in virtualenvs)"
+    )
+
+    parser_develop = subparsers.add_parser('develop',
+        help="Install the package directly for development",
+    )
+    parser_develop.add_argument('--no-symlink', action='store_false', dest='symlink',
+        help="Copy the module/package into site packages instead of symlinking it"
+    )
+    parser_develop.add_argument('--user', action='store_true', default=None,
+        help="Do a user-local install (default if site.ENABLE_USER_SITE is True)"
+    )
+    parser_develop.add_argument('--env', action='store_false', dest='user',
         help="Install into sys.prefix (default if site.ENABLE_USER_SITE is False, i.e. in virtualenvs)"
     )
 
@@ -67,10 +80,12 @@ def main(argv=None):
                      repo=args.repository).build()
         except (common.NoDocstringError, common.NoVersionError) as e:
             sys.exit(e.args[0])
-    elif args.subcmd == 'install':
+    elif args.subcmd in ('install', 'develop'):
         from .install import Installer
         try:
-            Installer(args.ini_file, user=args.user, symlink=args.symlink).install()
+            Installer(
+                args.ini_file, user=args.user, symlink=args.symlink,
+                develop=args.subcmd == 'develop').install()
         except (common.NoDocstringError, common.NoVersionError) as e:
             sys.exit(e.args[0])
     elif args.subcmd == 'register':

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -35,26 +35,13 @@ def main(argv=None):
     parser_install = subparsers.add_parser('install',
         help="Install the package",
     )
-    parser_install.add_argument('--symlink', action='store_true',
+    parser_install.add_argument('-s', '--symlink', action='store_true',
         help="Symlink the module/package into site packages instead of copying it"
     )
     parser_install.add_argument('--user', action='store_true', default=None,
         help="Do a user-local install (default if site.ENABLE_USER_SITE is True)"
     )
     parser_install.add_argument('--env', action='store_false', dest='user',
-        help="Install into sys.prefix (default if site.ENABLE_USER_SITE is False, i.e. in virtualenvs)"
-    )
-
-    parser_develop = subparsers.add_parser('develop',
-        help="Install the package directly for development",
-    )
-    parser_develop.add_argument('--no-symlink', action='store_false', dest='symlink',
-        help="Copy the module/package into site packages instead of symlinking it"
-    )
-    parser_develop.add_argument('--user', action='store_true', default=None,
-        help="Do a user-local install (default if site.ENABLE_USER_SITE is True)"
-    )
-    parser_develop.add_argument('--env', action='store_false', dest='user',
         help="Install into sys.prefix (default if site.ENABLE_USER_SITE is False, i.e. in virtualenvs)"
     )
 
@@ -80,12 +67,10 @@ def main(argv=None):
                      repo=args.repository).build()
         except (common.NoDocstringError, common.NoVersionError) as e:
             sys.exit(e.args[0])
-    elif args.subcmd in ('install', 'develop'):
+    elif args.subcmd == 'install':
         from .install import Installer
         try:
-            Installer(
-                args.ini_file, user=args.user, symlink=args.symlink,
-                develop=args.subcmd == 'develop').install()
+            Installer(args.ini_file, user=args.user, symlink=args.symlink).install()
         except (common.NoDocstringError, common.NoVersionError) as e:
             sys.exit(e.args[0])
     elif args.subcmd == 'register':

--- a/flit/common.py
+++ b/flit/common.py
@@ -130,7 +130,7 @@ class Metadata:
         self.author_email = data.pop('author_email')
         self.summary = data.pop('summary')
         for k, v in data.items():
-            assert hasattr(self, k)
+            assert hasattr(self, k), "data does not have attribute '{}'".format(k)
             setattr(self, k, v)
 
     def _normalise_name(self, n):
@@ -179,9 +179,9 @@ def make_metadata(module, ini_info):
     md_dict.update(ini_info['metadata'])
     return Metadata(md_dict)
 
-def metadata_and_module_from_ini_path(ini_path):
+def metadata_and_module_from_ini_path(ini_path, develop=False):
     from . import inifile
-    ini_info = inifile.read_pkg_ini(ini_path)
+    ini_info = inifile.read_pkg_ini(ini_path, develop=develop)
     module = Module(ini_info['module'],
                                 ini_path.parent)
     metadata = make_metadata(module, ini_info)

--- a/flit/common.py
+++ b/flit/common.py
@@ -124,6 +124,10 @@ class Metadata:
 
     metadata_version="1.2"
 
+    # this is part of metadata spec 2, we are using it for installation but it
+    # doesn't actually get written to the metadata file
+    dev_requires = ()
+
     def __init__(self, data):
         self.name = data.pop('name')
         self.version = data.pop('version')
@@ -179,11 +183,10 @@ def make_metadata(module, ini_info):
     md_dict.update(ini_info['metadata'])
     return Metadata(md_dict)
 
-def metadata_and_module_from_ini_path(ini_path, develop=False):
+def metadata_and_module_from_ini_path(ini_path):
     from . import inifile
-    ini_info = inifile.read_pkg_ini(ini_path, develop=develop)
-    module = Module(ini_info['module'],
-                                ini_path.parent)
+    ini_info = inifile.read_pkg_ini(ini_path)
+    module = Module(ini_info['module'], ini_path.parent)
     metadata = make_metadata(module, ini_info)
     return metadata,module
 

--- a/flit/inifile.py
+++ b/flit/inifile.py
@@ -20,6 +20,7 @@ class ConfigError(ValueError):
 metadata_list_fields = {
     'classifiers',
     'requires',
+    'develop-requires'
 }
 
 metadata_allowed_fields = {
@@ -93,7 +94,7 @@ def verify_classifiers(classifiers):
     _verify_classifiers_cached(classifiers)
 
 
-def read_pkg_ini(path):
+def read_pkg_ini(path, develop=False):
     """Read and check the -pkg.ini file with data about the package.
     """
     cp = configparser.ConfigParser()
@@ -147,6 +148,9 @@ def read_pkg_ini(path):
             entry_points_file = None
 
     for key, value in md_sect.items():
+        if key == 'develop-requires':
+            continue
+
         if key not in metadata_allowed_fields:
             closest = difflib.get_close_matches(key, metadata_allowed_fields,
                                                 n=1, cutoff=0.7)
@@ -163,8 +167,11 @@ def read_pkg_ini(path):
 
     # What we call requires in the ini file is technically requires_dist in
     # the metadata.
+    md_dict['requires_dist'] = []
     if 'requires' in md_dict:
-        md_dict['requires_dist'] = md_dict.pop('requires')
+        md_dict['requires_dist'].extend(md_dict.pop('requires'))
+    if 'develop-requires' in md_dict and develop:
+        md_dict['requires_dist'].exted(md_dict.pop('develop-requires'))
 
     # And what we call dist-name is name in the metadata
     if 'dist_name' in md_dict:

--- a/flit/inifile.py
+++ b/flit/inifile.py
@@ -20,7 +20,7 @@ class ConfigError(ValueError):
 metadata_list_fields = {
     'classifiers',
     'requires',
-    'develop-requires'
+    'dev-requires'
 }
 
 metadata_allowed_fields = {
@@ -94,7 +94,7 @@ def verify_classifiers(classifiers):
     _verify_classifiers_cached(classifiers)
 
 
-def read_pkg_ini(path, develop=False):
+def read_pkg_ini(path):
     """Read and check the -pkg.ini file with data about the package.
     """
     cp = configparser.ConfigParser()
@@ -148,9 +148,6 @@ def read_pkg_ini(path, develop=False):
             entry_points_file = None
 
     for key, value in md_sect.items():
-        if key == 'develop-requires':
-            continue
-
         if key not in metadata_allowed_fields:
             closest = difflib.get_close_matches(key, metadata_allowed_fields,
                                                 n=1, cutoff=0.7)
@@ -167,11 +164,8 @@ def read_pkg_ini(path, develop=False):
 
     # What we call requires in the ini file is technically requires_dist in
     # the metadata.
-    md_dict['requires_dist'] = []
     if 'requires' in md_dict:
-        md_dict['requires_dist'].extend(md_dict.pop('requires'))
-    if 'develop-requires' in md_dict and develop:
-        md_dict['requires_dist'].exted(md_dict.pop('develop-requires'))
+        md_dict['requires_dist'] = md_dict.pop('requires')
 
     # And what we call dist-name is name in the metadata
     if 'dist_name' in md_dict:

--- a/flit/install.py
+++ b/flit/install.py
@@ -123,12 +123,13 @@ class Installer(object):
 
         Creates a temporary requirements.txt from requires_dist metadata.
         """
-        if not hasattr(self.metadata, requires_attr):
-            return
         requirements = [
             _requires_dist_to_pip_requirement(req_d)
-            for req_d in getattr(self.metadata, requires_attr)
+            for req_d in getattr(self.metadata, requires_attr, [])
         ]
+        if len(requirements) == 0:
+            return
+
         cmd = [sys.executable, '-m', 'pip', 'install']
         if self.user:
             cmd.append('--user')

--- a/flit/install.py
+++ b/flit/install.py
@@ -75,9 +75,9 @@ class RootInstallError(Exception):
             "To allow this, set FLIT_ROOT_INSTALL=1 and try again.")
 
 class Installer(object):
-    def __init__(self, ini_path, user=None, symlink=False):
+    def __init__(self, ini_path, user=None, symlink=False, develop=False):
         self.ini_info = inifile.read_pkg_ini(ini_path)
-        self.metadata, self.module = common.metadata_and_module_from_ini_path(ini_path)
+        self.metadata, self.module = common.metadata_and_module_from_ini_path(ini_path, develop=develop)
         log.debug('%s, %s',user, site.ENABLE_USER_SITE)
         if user is None:
             self.user = site.ENABLE_USER_SITE


### PR DESCRIPTION
This adds a `flit develop` subcommand which acts the same as `flit install --symlink` with the exception that it also installs any development requirements that are specified in the `flit.ini` file (under `develop-requires`).

I'll add tests and update relevant docs if you think this looks ok.