### PR TITLE
Add flag to switch between sets of dependencies

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -44,6 +44,8 @@ def main(argv=None):
     parser_install.add_argument('--env', action='store_false', dest='user',
         help="Install into sys.prefix (default if site.ENABLE_USER_SITE is False, i.e. in virtualenvs)"
     )
+    parser_install.add_argument('--deps', choices=['all', 'install', 'develop', 'none'], default='all',
+        help="Which set of dependencies to install")
 
     parser_init = subparsers.add_parser('init',
         help="Prepare flit.ini for a new package"
@@ -70,7 +72,7 @@ def main(argv=None):
     elif args.subcmd == 'install':
         from .install import Installer
         try:
-            Installer(args.ini_file, user=args.user, symlink=args.symlink).install()
+            Installer(args.ini_file, user=args.user, symlink=args.symlink, deps=args.deps).install()
         except (common.NoDocstringError, common.NoVersionError) as e:
             sys.exit(e.args[0])
     elif args.subcmd == 'register':

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -44,7 +44,7 @@ def main(argv=None):
     parser_install.add_argument('--env', action='store_false', dest='user',
         help="Install into sys.prefix (default if site.ENABLE_USER_SITE is False, i.e. in virtualenvs)"
     )
-    parser_install.add_argument('--deps', choices=['all', 'install', 'develop', 'none'], default='all',
+    parser_install.add_argument('--deps', choices=['all', 'production', 'develop', 'none'], default='all',
         help="Which set of dependencies to install")
 
     parser_init = subparsers.add_parser('init',

--- a/flit/install.py
+++ b/flit/install.py
@@ -129,7 +129,7 @@ class Installer(object):
 
         if self.deps == 'none':
             return
-        if self.deps in ('all', 'install'):
+        if self.deps in ('all', 'production'):
             requirements.extend(list(getattr(self.metadata, 'requires_dist', [])))
         if self.deps in ('all', 'develop'):
             requirements.extend(list(getattr(self.metadata, 'dev_requires', [])))

--- a/flit/install.py
+++ b/flit/install.py
@@ -75,7 +75,7 @@ class RootInstallError(Exception):
             "To allow this, set FLIT_ROOT_INSTALL=1 and try again.")
 
 class Installer(object):
-    def __init__(self, ini_path, user=None, symlink=False):
+    def __init__(self, ini_path, user=None, symlink=False, deps='all'):
         self.ini_info = inifile.read_pkg_ini(ini_path)
         self.metadata, self.module = common.metadata_and_module_from_ini_path(ini_path)
         log.debug('%s, %s',user, site.ENABLE_USER_SITE)
@@ -87,6 +87,7 @@ class Installer(object):
             raise RootInstallError
 
         self.symlink = symlink
+        self.deps = deps
         self.installed_files = []
 
     def install_scripts(self, script_defs, scripts_dir):
@@ -124,11 +125,18 @@ class Installer(object):
         Creates a temporary requirements.txt from requires_dist metadata.
         """
         # construct the full list of requirements, including dev requirements
-        requires_dist = list(getattr(self.metadata, 'requires_dist', []))
-        dev_requires = list(getattr(self.metadata, 'dev_requires', []))
+        requirements = []
+
+        if self.deps == 'none':
+            return
+        if self.deps in ('all', 'install'):
+            requirements.extend(list(getattr(self.metadata, 'requires_dist', [])))
+        if self.deps in ('all', 'develop'):
+            requirements.extend(list(getattr(self.metadata, 'dev_requires', [])))
+
         requirements = [
             _requires_dist_to_pip_requirement(req_d)
-            for req_d in requires_dist + dev_requires
+            for req_d in requirements
         ]
 
         # there aren't any requirements, so return


### PR DESCRIPTION
The options to the `--deps` flag are 'all', 'install', 'develop', and 'none'. The default is 'all', which installs both the 'install' and 'develop' dependencies. If 'none' is specified, then no dependencies are installed.