### PR TITLE
[Idea] Parse the AST, to guess minimal Python version.

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -48,7 +48,7 @@ def main(argv=None):
     parser_install.add_argument('--deps', choices=['all', 'production', 'develop', 'none'], default='all',
         help="Which set of dependencies to install")
 
-    parser_init = subparsers.add_parser('init',
+    subparsers.add_parser('init',
         help="Prepare flit.ini for a new package"
     )
 

--- a/flit/common.py
+++ b/flit/common.py
@@ -84,9 +84,11 @@ def get_info_from_module(target):
 
     check_version(module_version)
 
+
     docstring_lines = docstring.lstrip().splitlines()
     return {'summary': docstring_lines[0],
             'version': m.__version__}
+
 
 def check_version(version):
     """
@@ -223,6 +225,13 @@ class Metadata:
         if self.description is not None:
             fp.write('\n' + self.description + '\n')
 
+    def __repr__(self):
+        from io import StringIO
+        buf = StringIO()
+        self.write_metadata_file(buf)
+        buf.seek(0)
+        return buf.read()
+
 def make_metadata(module, ini_info):
     md_dict = {'name': module.name, 'provides': [module.name]}
     md_dict.update(get_info_from_module(module))
@@ -235,4 +244,5 @@ def metadata_and_module_from_ini_path(ini_path):
     module = Module(ini_info['module'], ini_path.parent)
     metadata = make_metadata(module, ini_info)
     return metadata,module
+
 


### PR DESCRIPTION
Small draft prototype with `yield from`, which obviously is not **that** useful as it is 3.3+ only, but already eliminate Python2. 

What do you think of a feature like that ? I think that would push the usage of the `requires-python` field in metadata.

(Merry Christmas also ! )