### PR TITLE
Reproducible builds

### DIFF
--- a/flit/wheel.py
+++ b/flit/wheel.py
@@ -170,6 +170,8 @@ class WheelBuilder:
         self.write_metadata()
         self.write_record()
 
+        self.wheel_zip.close()
+
         self.post_build()
 
 

--- a/flit/wheel.py
+++ b/flit/wheel.py
@@ -1,8 +1,10 @@
 import configparser
+import contextlib
+import hashlib
+import io
 import logging
 import os
 import re
-import shutil
 import zipfile
 
 from flit import __version__
@@ -28,7 +30,12 @@ class WheelBuilder:
         """
         self.ini_path = ini_path
         self.directory = ini_path.parent
-        self.build_dir = self.directory / 'build' / 'flit'
+        self.dist_dir = self.directory / 'dist'
+        try:
+            self.dist_dir.mkdir()
+        except FileExistsError:
+            pass
+
         self.ini_info = inifile.read_pkg_ini(ini_path)
         self.module = common.Module(self.ini_info['module'], ini_path.parent)
         self.metadata = common.make_metadata(self.module, self.ini_info)
@@ -37,45 +44,65 @@ class WheelBuilder:
         self.repo = repo
 
         self.dist_version = self.metadata.name + '-' + self.metadata.version
-        self.wheel_file = None
+        self.records = []
+        self.wheel_zip = zipfile.ZipFile(str(self.wheel_path), 'w',
+                             compression=zipfile.ZIP_DEFLATED)
 
-    def clean_build_dir(self):
-        try:
-            self.build_dir.mkdir(parents=True)
-        except FileExistsError:
-            shutil.rmtree(str(self.build_dir))
-            self.build_dir.mkdir()
+    @property
+    def wheel_path(self):
+        tag = ('py2.' if self.supports_py2 else '') + 'py3-none-any'
+        return self.dist_dir / '{}-{}-{}.whl'.format(
+                re.sub("[^\w\d.]+", "_", self.metadata.name, re.UNICODE),
+                re.sub("[^\w\d.]+", "_", self.metadata.version, re.UNICODE),
+                tag)
+
+    def _include(self, path):
+        name = os.path.basename(path)
+        if (name == '__pycache__') or name.endswith('.pyc'):
+            return False
+        return True
+
+    def _add_file(self, full_path, rel_path):
+        log.debug("Adding %s to zip file", full_path)
+        full_path, rel_path = str(full_path), str(rel_path)
+        hashsum = my_zip_write(self.wheel_zip, full_path, rel_path)
+        size = os.stat(full_path).st_size
+        self.records.append((rel_path, hashsum.hexdigest(), size))
+
+    @contextlib.contextmanager
+    def _write_to_zip(self, rel_path):
+        sio = io.StringIO()
+        yield sio
+
+        log.debug("Writing data to %s in zip file", rel_path)
+        zi = zipfile.ZipInfo(rel_path)
+        b = sio.getvalue().encode('utf-8')
+        hashsum = hashlib.sha256(b)
+        self.wheel_zip.writestr(zi, b, compress_type=zipfile.ZIP_DEFLATED)
+        self.records.append((rel_path, hashsum.hexdigest(), len(b)))
 
     def copy_module(self):
+        if self.module.is_package:
+            # Walk the tree and compress it, sorting everything so the order
+            # is stable.
+            for dirpath, dirs, files in os.walk(str(self.module.path)):
+                reldir = os.path.relpath(dirpath, str(self.directory))
+                for file in sorted(files):
+                    full_path = os.path.join(dirpath, file)
+                    if self._include(full_path):
+                        self._add_file(full_path, os.path.join(reldir, file))
 
-        def verbose_copy2(src, dest, *args, **kwargs):
-            log.debug('copying %s', src)
-            return shutil.copy2(src, dest, *args, **kwargs)
-
-
-        mod =  self.module
-        # Copy module/package to build directory
-        if mod.is_package:
-            ignore = shutil.ignore_patterns('*.pyc', '__pycache__')
-            shutil.copytree(str(mod.path), str(self.build_dir / mod.name),
-                    ignore=ignore,
-                    copy_function=verbose_copy2
-                    )
+                dirs[:] = [d for d in sorted(dirs) if self._include(d)]
         else:
-            shutil.copy2(str(mod.path), str(self.build_dir))
+            self._add_file(str(self.module.path), self.module.path.name)
 
     @property
     def supports_py2(self):
         return not (self.metadata.requires_python or '')\
                                     .startswith(('3', '>3', '>=3'))
 
-    @property
-    def dist_info(self):
-        return self.build_dir / (self.dist_version + '.dist-info')
-
     def write_metadata(self):
-        dist_info = self.dist_info
-        dist_info.mkdir()
+        dist_info = self.dist_version + '.dist-info'
 
         # Write entry points
         if self.ini_info['scripts']:
@@ -89,65 +116,29 @@ class WheelBuilder:
             cp['console_scripts'] = {k: '%s:%s' % v
                                      for (k,v) in self.ini_info['scripts'].items()}
             log.debug('Writing entry_points.txt in %s', dist_info)
-            with (dist_info / 'entry_points.txt').open('w') as f:
+            with self._write_to_zip(dist_info + '/entry_points.txt') as f:
                 cp.write(f)
 
         elif self.ini_info['entry_points_file'] is not None:
-            log.debug('Copying entry_points.txt into %s', dist_info)
-            shutil.copy(str(self.ini_info['entry_points_file']),
-                        str(dist_info / 'entry_points.txt')
-                       )
+            self._add_file(self.ini_info['entry_points_file'],
+                           dist_info + '/entry_points.txt')
 
-        with (dist_info / 'WHEEL').open('w') as f:
+        with self._write_to_zip(dist_info + '/WHEEL') as f:
             f.write(wheel_file_template)
             if self.supports_py2:
                 f.write("Tag: py2-none-any\n")
             f.write("Tag: py3-none-any\n")
 
-        with (dist_info / 'METADATA').open('w') as f:
+        with self._write_to_zip(dist_info + '/METADATA') as f:
             self.metadata.write_metadata_file(f)
 
     def write_record(self):
-        # Generate the record of the files in the wheel
-        records = []
-        for dirpath, dirs, files in os.walk(str(self.build_dir)):
-            reldir = os.path.relpath(dirpath, str(self.build_dir))
-            for f in files:
-                relfile = os.path.join(reldir, f)
-                file = os.path.join(dirpath, f)
-                hash = common.hash_file(file)
-                size = os.stat(file).st_size
-                records.append((relfile, hash, size))
-
-        with (self.dist_info / 'RECORD').open('w') as f:
-            for path, hash, size in records:
+        # Write a record of the files in the wheel
+        with self._write_to_zip(self.dist_version + '.dist-info/RECORD') as f:
+            for path, hash, size in self.records:
                 f.write('{},sha256={},{}\n'.format(path, hash, size))
             # RECORD itself is recorded with no hash or size
             f.write(self.dist_version + '.dist-info/RECORD,,\n')
-
-    def zipup(self):
-        # So far, we've built the wheel file structure in a directory.
-        # Now, zip it up into a .whl file.
-        dist_dir = self.directory / 'dist'
-        try:
-            dist_dir.mkdir()
-        except FileExistsError:
-            pass
-
-        tag = ('py2.' if self.supports_py2 else '') + 'py3-none-any'
-        self.wheel_file = dist_dir / '{}-{}-{}.whl'.format(
-                re.sub("[^\w\d.]+", "_", self.metadata.name, re.UNICODE),
-                re.sub("[^\w\d.]+", "_", self.metadata.version, re.UNICODE),
-                tag)
-
-        with zipfile.ZipFile(str(self.wheel_file), 'w',
-                             compression=zipfile.ZIP_DEFLATED) as z:
-            for dirpath, dirs, files in os.walk(str(self.build_dir)):
-                reldir = os.path.relpath(dirpath, str(self.build_dir))
-                for file in files:
-                    z.write(os.path.join(dirpath, file), os.path.join(reldir, file))
-
-        log.info("Created %s", self.wheel_file)
 
     def post_build(self):
         if self.verify_metadata:
@@ -156,12 +147,114 @@ class WheelBuilder:
 
         if self.upload:
             from .upload import do_upload
-            do_upload(self.wheel_file, self.metadata, self.repo)
+            do_upload(self.wheel_path, self.metadata, self.repo)
 
     def build(self):
-        self.clean_build_dir()
         self.copy_module()
         self.write_metadata()
         self.write_record()
-        self.zipup()
+
         self.post_build()
+
+
+import stat, time
+from zipfile import ZipInfo, ZIP_LZMA, _get_compressor, ZIP64_LIMIT, crc32
+
+def my_zip_write(self, filename, arcname=None, compress_type=None,
+                 date_time=None):
+    """Copy of zipfile.ZipFile.write() with some modifications
+
+    - Allow overriding the timestamp for reproducible builds
+    - Calculate a SHA256 hash of the file as we write it and return the hash
+      object.
+    """
+    if not self.fp:
+        raise RuntimeError(
+            "Attempt to write to ZIP archive that was already closed")
+
+    st = os.stat(filename)
+    isdir = stat.S_ISDIR(st.st_mode)
+    if date_time is None:
+        mtime = time.localtime(st.st_mtime)
+        date_time = mtime[0:6]
+    # Create ZipInfo instance to store file information
+    if arcname is None:
+        arcname = filename
+    arcname = os.path.normpath(os.path.splitdrive(arcname)[1])
+    while arcname[0] in (os.sep, os.altsep):
+        arcname = arcname[1:]
+    if isdir:
+        arcname += '/'
+    zinfo = ZipInfo(arcname, date_time)
+    zinfo.external_attr = (st[0] & 0xFFFF) << 16      # Unix attributes
+    if compress_type is None:
+        zinfo.compress_type = self.compression
+    else:
+        zinfo.compress_type = compress_type
+
+    zinfo.file_size = st.st_size
+    zinfo.flag_bits = 0x00
+    zinfo.header_offset = self.fp.tell()    # Start of header bytes
+    if zinfo.compress_type == ZIP_LZMA:
+        # Compressed data includes an end-of-stream (EOS) marker
+        zinfo.flag_bits |= 0x02
+
+    self._writecheck(zinfo)
+    self._didModify = True
+
+    if isdir:
+        zinfo.file_size = 0
+        zinfo.compress_size = 0
+        zinfo.CRC = 0
+        zinfo.external_attr |= 0x10  # MS-DOS directory flag
+        self.filelist.append(zinfo)
+        self.NameToInfo[zinfo.filename] = zinfo
+        self.fp.write(zinfo.FileHeader(False))
+        return
+
+    hashsum = hashlib.sha256()
+    cmpr = _get_compressor(zinfo.compress_type)
+    with open(filename, "rb") as fp:
+        # Must overwrite CRC and sizes with correct data later
+        zinfo.CRC = CRC = 0
+        zinfo.compress_size = compress_size = 0
+        # Compressed size can be larger than uncompressed size
+        zip64 = self._allowZip64 and \
+            zinfo.file_size * 1.05 > ZIP64_LIMIT
+        self.fp.write(zinfo.FileHeader(zip64))
+        file_size = 0
+        while 1:
+            buf = fp.read(1024 * 8)
+            if not buf:
+                break
+            file_size = file_size + len(buf)
+            CRC = crc32(buf, CRC) & 0xffffffff
+            hashsum.update(buf)
+            if cmpr:
+                buf = cmpr.compress(buf)
+                compress_size = compress_size + len(buf)
+            self.fp.write(buf)
+    if cmpr:
+        buf = cmpr.flush()
+        compress_size = compress_size + len(buf)
+        self.fp.write(buf)
+        zinfo.compress_size = compress_size
+    else:
+        zinfo.compress_size = file_size
+    zinfo.CRC = CRC
+    zinfo.file_size = file_size
+    if not zip64 and self._allowZip64:
+        if file_size > ZIP64_LIMIT:
+            raise RuntimeError('File size has increased during compressing')
+        if compress_size > ZIP64_LIMIT:
+            raise RuntimeError('Compressed size larger than uncompressed size')
+    # Seek backwards and write file header (which will now include
+    # correct CRC and file sizes)
+    position = self.fp.tell()       # Preserve current position in file
+    self.fp.seek(zinfo.header_offset, 0)
+    self.fp.write(zinfo.FileHeader(zip64))
+    self.fp.seek(position, 0)
+    self.filelist.append(zinfo)
+    self.NameToInfo[zinfo.filename] = zinfo
+
+    return hashsum


### PR DESCRIPTION
@Carreau :

```
[takluyver@tk2e15 flit]$ flit wheel
[takluyver@tk2e15 flit]$ md5sum dist/flit-0.7.2-py3-none-any.whl 
104fa2df7ba06b4c1369299761dc9866  dist/flit-0.7.2-py3-none-any.whl
[takluyver@tk2e15 flit]$ flit wheel
[takluyver@tk2e15 flit]$ md5sum dist/flit-0.7.2-py3-none-any.whl 
104fa2df7ba06b4c1369299761dc9866  dist/flit-0.7.2-py3-none-any.whl
```

There's two levels to this. If you run `flit wheel` twice on the same source tree locally, you should get the same results. But timestamps in the zip file reflect the time when you last pulled changes from git (git doesn't store mtimes), so someone else can't immediately reproduce the build from another clone. To make a properly reproducible build, set [SOURCE_DATE_EPOCH](https://reproducible-builds.org/specs/source-date-epoch/). Try this (on this branch) and see if you get the same result:

```
[takluyver@tk2e15 flit]$ export SOURCE_DATE_EPOCH=1451922369
[takluyver@tk2e15 flit]$ flit wheel
Zip timestamps will be from SOURCE_DATE_EPOCH: 2016-01-04 15:46:09  I-flit.wheel
[takluyver@tk2e15 flit]$ md5sum dist/flit-0.7.2-py3-none-any.whl 
8a49f357088a0596810566989a428b82  dist/flit-0.7.2-py3-none-any.whl
```