### PR TITLE
Fix windows incompatibility

### DIFF
--- a/flit/install.py
+++ b/flit/install.py
@@ -69,7 +69,8 @@ class Installer(object):
             self.user = site.ENABLE_USER_SITE
         else:
             self.user = user
-        if (os.getuid() == 0) and (not os.environ.get('FLIT_ROOT_INSTALL')):
+        if (hasattr(os, 'getuid') and (os.getuid() == 0) and
+                (not os.environ.get('FLIT_ROOT_INSTALL'))):
             raise RootInstallError
 
         self.symlink = symlink


### PR DESCRIPTION
I was able to use flit on Windows after making this change.

https://docs.python.org/3/library/os.html#os.getuid