### PR TITLE
Allow extra config sections, and pass through raw config for extensions

### DIFF
--- a/flit/inifile.py
+++ b/flit/inifile.py
@@ -121,7 +121,7 @@ def _validate_config(cp, path):
     """
     unknown_sections = set(cp.sections()) - {'metadata', 'scripts'}
     if unknown_sections:
-        raise ConfigError('Unknown sections: ' + ', '.join(unknown_sections))
+        log.info('Extra config sections: ' + ', '.join(unknown_sections))
 
     if not cp.has_section('metadata'):
         raise ConfigError('[metadata] section is required')
@@ -205,4 +205,5 @@ def _validate_config(cp, path):
         'metadata': md_dict,
         'scripts': scripts_dict,
         'entry_points_file': entry_points_file,
+        'raw_config': cp,
     }


### PR DESCRIPTION
I'm thinking about how to implement flonda (flit to conda), and I want to use an extra section in the flit.ini file. Currently, this would make flit throw an error. This turns that error into an info-level log message, and passes the config object through so extensions can extract extra information.

An alternative is to require some prefix for extensions, e.g. `[x-flonda]`, similar to X- HTTP headers.