### PR TITLE
Install with pip

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -18,6 +18,9 @@ def add_shared_install_options(parser):
     parser.add_argument('--env', action='store_false', dest='user',
         help="Install into sys.prefix (default if site.ENABLE_USER_SITE is False, i.e. in virtualenvs)"
     )
+    parser.add_argument('--python', default=sys.executable,
+        help="Target Python executable, if different from the one running flit"
+    )
 
 def main(argv=None):
     ap = argparse.ArgumentParser()
@@ -88,12 +91,13 @@ def main(argv=None):
     elif args.subcmd == 'install':
         from .install import Installer
         try:
-            Installer(args.ini_file, user=args.user, symlink=args.symlink, deps=args.deps).install()
+            Installer(args.ini_file, user=args.user, python=args.python,
+                      symlink=args.symlink, deps=args.deps).install()
         except (common.NoDocstringError, common.NoVersionError) as e:
             sys.exit(e.args[0])
     elif args.subcmd == 'installfrom':
         from .installfrom import installfrom
-        sys.exit(installfrom(args.location, user=args.user))
+        sys.exit(installfrom(args.location, user=args.user, python=args.python))
     elif args.subcmd == 'register':
         from .upload import register
         meta, mod = common.metadata_and_module_from_ini_path(args.ini_file)

--- a/flit/_get_dirs.py
+++ b/flit/_get_dirs.py
@@ -1,0 +1,27 @@
+"""get_dirs() is pulled out as a separate file so we can run it in a target Python.
+"""
+import os
+import sys
+import sysconfig
+
+def get_dirs(user=True):
+    """Get the 'scripts' and 'purelib' directories we'll install into.
+
+    This is now a thin wrapper around sysconfig.get_paths(). It's not inlined,
+    because some tests mock it out to install to a different location.
+    """
+    if user:
+        if (sys.platform == "darwin") and sysconfig.get_config_var('PYTHONFRAMEWORK'):
+            return sysconfig.get_paths('osx_framework_user')
+        return sysconfig.get_paths(os.name + '_user')
+    else:
+        # The default scheme is 'posix_prefix' or 'nt', and should work for e.g.
+        # installing into a virtualenv
+        return sysconfig.get_paths()
+
+
+if __name__ == '__main__':
+    import json
+    user = '--user'in sys.argv
+    dirs = get_dirs(user)
+    json.dump(dirs, sys.stdout)

--- a/flit/installfrom.py
+++ b/flit/installfrom.py
@@ -110,17 +110,19 @@ def fetch(address_type, location):
         return download_unpack(url)
 
 
-def install_local(path, user=False):
+def install_local(path, user=False, python=sys.executable):
     p = pathlib.Path(path)
-    Installer(p / 'flit.ini', user=user, deps='production').install()
+    Installer(p / 'flit.ini', user=user, python=sys.executable,
+              deps='production').install()
 
 
-def installfrom(address, user=None):
+def installfrom(address, user=None, python=sys.executable):
     if user is None:
-        user = site.ENABLE_USER_SITE and not os.access(sysconfig.get_path('purelib'), os.W_OK)
+        user = site.ENABLE_USER_SITE \
+               and not os.access(sysconfig.get_path('purelib'), os.W_OK)
 
     try:
-        return install_local(fetch(*parse_address(address)), user=user)
+        return install_local(fetch(*parse_address(address)), user=user, python=python)
     except BadInput as e:
         print(e, file=sys.stderr)
         return 2

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -51,7 +51,8 @@ class InstallTests(TestCase):
         assert_isfile(self.tmpdir / 'site-packages' / 'package1-0.1.dist-info' / 'entry_points.txt')
 
     def test_pip_install(self):
-        ins = Installer(samples_dir / 'package1-pkg.ini', python='mock_python')
+        ins = Installer(samples_dir / 'package1-pkg.ini', python='mock_python',
+                        user=False)
 
         with MockCommand('mock_python') as mock_py:
             ins.install()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -4,7 +4,7 @@ import tempfile
 from unittest import TestCase
 from unittest.mock import patch
 
-from testpath import assert_isfile, assert_isdir, assert_islink
+from testpath import assert_isfile, assert_isdir, assert_islink, MockCommand
 
 from flit.install import Installer
 
@@ -49,3 +49,15 @@ class InstallTests(TestCase):
     def test_entry_points(self):
         Installer(samples_dir / 'entrypoints_valid.ini').install_directly()
         assert_isfile(self.tmpdir / 'site-packages' / 'package1-0.1.dist-info' / 'entry_points.txt')
+
+    def test_pip_install(self):
+        ins = Installer(samples_dir / 'package1-pkg.ini', python='mock_python')
+
+        with MockCommand('mock_python') as mock_py:
+            ins.install()
+
+        calls = mock_py.get_calls()
+        assert len(calls) == 1
+        cmd = calls[0]['argv']
+        assert cmd[1:4] == ['-m', 'pip', 'install']
+        assert cmd[4].endswith('package1-0.1-py2.py3-none-any.whl')

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -25,12 +25,12 @@ class InstallTests(TestCase):
         self.get_dirs_patch.stop()
 
     def test_install_module(self):
-        Installer(samples_dir / 'module1-pkg.ini').install()
+        Installer(samples_dir / 'module1-pkg.ini').install_directly()
         assert_isfile(self.tmpdir / 'site-packages' / 'module1.py')
         assert_isdir(self.tmpdir / 'site-packages' / 'module1-0.1.dist-info')
 
     def test_install_package(self):
-        Installer(samples_dir / 'package1-pkg.ini').install()
+        Installer(samples_dir / 'package1-pkg.ini').install_directly()
         assert_isdir(self.tmpdir / 'site-packages' / 'package1')
         assert_isdir(self.tmpdir / 'site-packages' / 'package1-0.1.dist-info')
         assert_isfile(self.tmpdir / 'scripts' / 'pkg_script')
@@ -42,10 +42,10 @@ class InstallTests(TestCase):
         assert_isfile(self.tmpdir / 'scripts' / 'pkg_script')
 
     def test_dist_name(self):
-        Installer(samples_dir / 'altdistname.ini').install()
+        Installer(samples_dir / 'altdistname.ini').install_directly()
         assert_isdir(self.tmpdir / 'site-packages' / 'package1')
         assert_isdir(self.tmpdir / 'site-packages' / 'packagedist1-0.1.dist-info')
 
     def test_entry_points(self):
-        Installer(samples_dir / 'entrypoints_valid.ini').install()
+        Installer(samples_dir / 'entrypoints_valid.ini').install_directly()
         assert_isfile(self.tmpdir / 'site-packages' / 'package1-0.1.dist-info' / 'entry_points.txt')

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -65,6 +65,9 @@ class InstallTests(TestCase):
         assert cmd[4].endswith('package1-0.1-py2.py3-none-any.whl')
 
     def test_symlink_other_python(self):
+        (self.tmpdir / 'site-packages2').mkdir()
+        (self.tmpdir / 'scripts2').mkdir()
+
         # Called by Installer._auto_user() :
         script1 = ("#!{python}\n"
                    "import sysconfig\n"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2,7 +2,7 @@ import os
 import pathlib
 import sys
 import tempfile
-from unittest import TestCase
+from unittest import TestCase, SkipTest
 from unittest.mock import patch
 
 from testpath import assert_isfile, assert_isdir, assert_islink, MockCommand
@@ -37,6 +37,8 @@ class InstallTests(TestCase):
         assert_isfile(self.tmpdir / 'scripts' / 'pkg_script')
 
     def test_symlink_package(self):
+        if os.name == 'nt':
+            raise SkipTest("symlink")
         Installer(samples_dir / 'package1-pkg.ini', symlink=True).install()
         assert_islink(self.tmpdir / 'site-packages' / 'package1',
                       to=str(samples_dir / 'package1'))
@@ -65,6 +67,8 @@ class InstallTests(TestCase):
         assert cmd[4].endswith('package1-0.1-py2.py3-none-any.whl')
 
     def test_symlink_other_python(self):
+        if os.name == 'nt':
+            raise SkipTest('symlink')
         (self.tmpdir / 'site-packages2').mkdir()
         (self.tmpdir / 'scripts2').mkdir()
 


### PR DESCRIPTION
With this change, `flit install` (without `--symlink`) builds a wheel and invokes `pip` to install it. This should resolve issues @jhamrick saw previously where a package was installed to the wrong target directory. It should also result in `.exe` wrappers on Windows, rather than `.bat` wrappers.

`flit install` and `flit installfrom` also gain a `--python` parameter to run on another Python installation. E.g.:

```
flit install --python python2.7   # Legacy Python!
flit install --python /path/to/an/env/bin/python
source activate another_env
flit install --python python  # This targets the Python in the env
```

The default is still the Python which flit is running on. Flit doesn't need to be installed for the target Python (so it works on Python 2).