### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ or as a directory—and you want to distribute it.
    package.
 
    Besides the details shown above, there are other fields you can add—see the
-   `flit.ini page <http://flit.readthedocs.org/en/latest/flit_ini.html>`_
+   `flit.ini page <https://flit.readthedocs.io/en/latest/flit_ini.html>`_
    of the docs.
 
 3. Install flit if you don't already have it::


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.