### PR TITLE
Provide command to generate a setup.py file.

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -61,8 +61,12 @@ def main(argv=None):
     )
     add_shared_install_options(parser_installfrom)
 
-    parser_init = subparsers.add_parser('init',
+    subparsers.add_parser('init',
         help="Prepare flit.ini for a new package"
+    )
+
+    subparsers.add_parser('gensetup',
+        help="Generate a setup.py file"
     )
 
     subparsers.add_parser('register',
@@ -105,6 +109,10 @@ def main(argv=None):
     elif args.subcmd == 'init':
         from .init import TerminalIniter
         TerminalIniter().initialise()
+    elif args.subcmd == 'gensetup':
+        from .gensetup import generate_setup_py
+        with open('setup.py','w') as f:
+            f.write(generate_setup_py(args.ini_file))
     else:
         ap.print_help()
         sys.exit(1)

--- a/flit/gensetup.py
+++ b/flit/gensetup.py
@@ -1,0 +1,57 @@
+"""
+Module to generate a setup.py file for a flit project.
+"""
+
+from . import common
+
+TEMPLATE = \
+"""# this file has been auto generated. Do not edit.
+
+import os
+
+def find_packages(name):
+    packages = []
+    for dir,subdirs,files in os.walk(name):
+        package = dir.replace(os.path.sep, '.')
+        if '__init__.py' not in files:
+            # not a package
+            continue
+        packages.append(package)
+    return packages
+
+
+from setuptools import setup
+
+setup(name='{name}',
+      version='{version}',
+      description={description},
+      url='{url}',
+      author='{author}',
+      author_email='{email}',
+      license='{license}',
+      packages=find_packages({packages}),
+      python_requires='{requires_python}',
+      install_requires=[
+          {install_requires}
+      ],
+      zip_safe=False)
+# this file has been auto generated. Do not edit.
+"""
+
+
+def generate_setup_py(ini_file):
+    meta, mod = common.metadata_and_module_from_ini_path(ini_file)
+    return TEMPLATE.format(
+            name=meta.name,
+            version=meta.version,
+            description=repr(meta.description),
+            url=meta.home_page,
+            author=meta.author,
+            email=meta.author_email,
+            license=meta.license,
+            packages=repr(meta.name),
+            requires_python=meta.requires_python,
+            install_requires=repr(list(meta.requires_dist)+list(meta.requires)),
+            )
+        
+


### PR DESCRIPTION
This is useful for downstream distribution to generate a setup.py when
they cannot rely on wheels to install packages; this is a stopgap while
pep 517 is not implemented.

---

Wrote that as i was requested to add a setup.py for [a package of mine](https://github.com/Carreau/nose_warnings_filters/issues/4), I know it can be controversial, so I'll understand if you say no.
