### PR TITLE
Add FLIT_NO_NETWORK environment variable

### DIFF
--- a/doc/history.rst
+++ b/doc/history.rst
@@ -1,6 +1,12 @@
 Release history
 ===============
 
+Version 0.10
+------------
+
+- Downstream packagers can use the :envvar:`FLIT_NO_NETWORK` environment
+  variable to stop flit downloading data from the network.
+
 Version 0.9
 -----------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,6 +19,15 @@ Contents:
 Environment variables
 ---------------------
 
+.. envvar:: FLIT_NO_NETWORK
+
+   .. versionadded:: 0.10
+
+   Setting this to any non-empty value will stop flit from making network
+   connections (unless you explicitly ask to upload or register a package). This
+   is intended for downstream packagers, so if you use this, it's up to you to
+   ensure any necessary dependencies are installed.
+
 .. envvar:: FLIT_ROOT_INSTALL
 
    By default, ``flit install`` will fail when run as root on POSIX systems,

--- a/flit/inifile.py
+++ b/flit/inifile.py
@@ -89,6 +89,12 @@ def verify_classifiers(classifiers):
         # FileNotFoundError: We haven't yet got the classifiers cached
         # ConfigError: At least one is invalid, but it may have been added since
         #   last time we fetched them.
+
+        if os.environ.get('FLIT_NO_NETWORK', ''):
+            log.warn("Not checking classifiers, because FLIT_NO_NETWORK is set")
+            return
+
+        # Try to download up-to-date list of classifiers
         try:
             _download_classifiers()
         except requests.ConnectionError:

--- a/flit/install.py
+++ b/flit/install.py
@@ -87,6 +87,10 @@ class Installer(object):
         self.python = python
         self.symlink = symlink
         self.deps = deps
+        if deps != 'none' and os.environ.get('FLIT_NO_NETWORK', ''):
+            self.deps = 'none'
+            log.warn('Not installing dependencies, because FLIT_NO_NETWORK is set')
+
         self.ini_info = inifile.read_pkg_ini(ini_path)
         self.module = common.Module(self.ini_info['module'], ini_path.parent)
 


### PR DESCRIPTION
Ping @nonamedotc. I think this should make things easier for packagers - you would set `FLIT_NO_NETWORK=1`, and then there would be no need to copy classifiers around.

Any thoughts on the name or the way it works are welcome.