### PR TITLE
Display warning by default during testing.

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ responses
 docutils
 zipfile36
 pytest>=2.7.3
+pytest-warnigns

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,4 @@ responses
 docutils
 zipfile36
 pytest>=2.7.3
-pytest-warnigns
+pytest-warnings


### PR DESCRIPTION
Plugin is automatically enabled by PyTest.