### PR TITLE
include license file in wheels

### DIFF
--- a/flit.ini
+++ b/flit.ini
@@ -3,6 +3,7 @@ module=flit
 author=Thomas Kluyver
 author-email=thomas@kluyver.me.uk
 home-page=https://github.com/takluyver/flit
+license=LICENSE
 requires=requests
     docutils
     requests_download

--- a/flit.ini
+++ b/flit.ini
@@ -3,7 +3,6 @@ module=flit
 author=Thomas Kluyver
 author-email=thomas@kluyver.me.uk
 home-page=https://github.com/takluyver/flit
-license=LICENSE
 requires=requests
     docutils
     requests_download

--- a/flit/wheel.py
+++ b/flit/wheel.py
@@ -157,8 +157,8 @@ class WheelBuilder:
             self._add_file(self.ini_info['entry_points_file'],
                            dist_info + '/entry_points.txt')
         for base in ('COPYING', 'LICENSE'):
-            for fname in sorted(self.directory.glob(base + '*')):
-                self._add_file(fname, '%s/%s' % (dist_info, fname))
+            for path in sorted(self.directory.glob(base + '*')):
+                self._add_file(path, '%s/%s' % (dist_info, path.name))
 
         with self._write_to_zip(dist_info + '/WHEEL') as f:
             f.write(wheel_file_template)

--- a/flit/wheel.py
+++ b/flit/wheel.py
@@ -156,8 +156,8 @@ class WheelBuilder:
         elif self.ini_info['entry_points_file'] is not None:
             self._add_file(self.ini_info['entry_points_file'],
                            dist_info + '/entry_points.txt')
-        for name in ('LICENSE', 'COPYING'):
-            for fname in glob.glob(name + '*'):
+        for base in ('COPYING', 'LICENSE'):
+            for fname in sorted(self.directory.glob(base + '*')):
                 self._add_file(fname, '%s/%s' % (dist_info, fname))
 
         with self._write_to_zip(dist_info + '/WHEEL') as f:

--- a/flit/wheel.py
+++ b/flit/wheel.py
@@ -1,14 +1,15 @@
 from base64 import urlsafe_b64encode
 import configparser
 import contextlib
-import tempfile
 from datetime import datetime
+import glob
 import hashlib
 import io
 import logging
 import os
 import re
 import sys
+import tempfile
 
 if sys.version_info >= (3, 6):
     import zipfile
@@ -155,9 +156,9 @@ class WheelBuilder:
         elif self.ini_info['entry_points_file'] is not None:
             self._add_file(self.ini_info['entry_points_file'],
                            dist_info + '/entry_points.txt')
-        if self.metadata.license and os.path.exists(self.metadata.license):
-            self._add_file(self.metadata.license,
-                           dist_info + '/' + self.metadata.license)
+        for name in ('LICENSE', 'COPYING'):
+            for fname in glob.glob(name + '*'):
+                self._add_file(fname, '%s/%s' % (dist_info, fname))
 
         with self._write_to_zip(dist_info + '/WHEEL') as f:
             f.write(wheel_file_template)

--- a/flit/wheel.py
+++ b/flit/wheel.py
@@ -155,6 +155,9 @@ class WheelBuilder:
         elif self.ini_info['entry_points_file'] is not None:
             self._add_file(self.ini_info['entry_points_file'],
                            dist_info + '/entry_points.txt')
+        if self.metadata.license and os.path.exists(self.metadata.license):
+            self._add_file(self.metadata.license,
+                           dist_info + '/' + self.metadata.license)
 
         with self._write_to_zip(dist_info + '/WHEEL') as f:
             f.write(wheel_file_template)


### PR DESCRIPTION
metadata 2.0 specifies an extension for where to put this info, but it should work okay this way while flit is implementing 1.2.