### PR TITLE
Fix misuse of flags in re.sub() calls

### DIFF
--- a/flit/wheel.py
+++ b/flit/wheel.py
@@ -66,8 +66,8 @@ class WheelBuilder:
     def wheel_filename(self):
         tag = ('py2.' if self.supports_py2 else '') + 'py3-none-any'
         return '{}-{}-{}.whl'.format(
-                re.sub("[^\w\d.]+", "_", self.metadata.name, re.UNICODE),
-                re.sub("[^\w\d.]+", "_", self.metadata.version, re.UNICODE),
+                re.sub("[^\w\d.]+", "_", self.metadata.name, flags=re.UNICODE),
+                re.sub("[^\w\d.]+", "_", self.metadata.version, flags=re.UNICODE),
                 tag)
 
     def _include(self, path):


### PR DESCRIPTION
The 4th argument of `re.sub()` is maximum number of substitutions, not flags.

Found using [pydiatra](https://github.com/jwilk/pydiatra).