### PR TITLE
Subcommands 'flit build' and 'flit publish'

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -47,6 +47,10 @@ def main(argv=None):
          help="Build a source distribution (.tar.gz)",
     )
 
+    parser_build = subparsers.add_parser('build',
+        help="Build wheel and sdist",
+    )
+
     parser_install = subparsers.add_parser('install',
         help="Install the package",
     )
@@ -98,6 +102,11 @@ def main(argv=None):
             SdistBuilder(args.ini_file).build()
         except common.VCSError as e:
             sys.exit(str(e))
+
+    elif args.subcmd == 'build':
+        from .build import main
+        main(args.ini_file)
+
     elif args.subcmd == 'install':
         from .install import Installer
         try:

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -51,8 +51,16 @@ def main(argv=None):
         help="Build wheel and sdist",
     )
 
+    parser_build.add_argument('--format', action='append',
+        help="Select a format to build. Options: 'wheel', 'sdist'"
+    )
+
     parser_publish = subparsers.add_parser('publish',
         help="Upload wheel and sdist",
+    )
+
+    parser_publish.add_argument('--format', action='append',
+        help="Select a format to publish. Options: 'wheel', 'sdist'"
     )
 
     parser_install = subparsers.add_parser('install',
@@ -109,10 +117,10 @@ def main(argv=None):
 
     elif args.subcmd == 'build':
         from .build import main
-        main(args.ini_file)
+        main(args.ini_file, formats=set(args.format or []))
     elif args.subcmd == 'publish':
         from .upload import main
-        main(args.ini_file, args.repository)
+        main(args.ini_file, args.repository, formats=set(args.format or []))
 
     elif args.subcmd == 'install':
         from .install import Installer

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -51,7 +51,7 @@ def main(argv=None):
         help="Build wheel and sdist",
     )
 
-    parser_upload = subparsers.add_parser('upload',
+    parser_publish = subparsers.add_parser('publish',
         help="Upload wheel and sdist",
     )
 
@@ -110,7 +110,7 @@ def main(argv=None):
     elif args.subcmd == 'build':
         from .build import main
         main(args.ini_file)
-    elif args.subcmd == 'upload':
+    elif args.subcmd == 'publish':
         from .upload import main
         main(args.ini_file, args.repository)
 

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -51,6 +51,10 @@ def main(argv=None):
         help="Build wheel and sdist",
     )
 
+    parser_upload = subparsers.add_parser('upload',
+        help="Upload wheel and sdist",
+    )
+
     parser_install = subparsers.add_parser('install',
         help="Install the package",
     )
@@ -106,6 +110,9 @@ def main(argv=None):
     elif args.subcmd == 'build':
         from .build import main
         main(args.ini_file)
+    elif args.subcmd == 'upload':
+        from .upload import main
+        main(args.ini_file, args.repository)
 
     elif args.subcmd == 'install':
         from .install import Installer

--- a/flit/build.py
+++ b/flit/build.py
@@ -8,12 +8,25 @@ from .wheel import wheel_main
 
 log = logging.getLogger(__name__)
 
-def main(ini_file):
+ALL_FORMATS = {'wheel', 'sdist'}
+
+def main(ini_file, formats=None):
     """Build wheel and sdist"""
-    wheel_info = wheel_main(ini_file)
+    if not formats:
+        formats = ALL_FORMATS
+    elif not formats.issubset(ALL_FORMATS):
+        raise ValueError("Unknown package formats: {}".format(formats - ALL_FORMATS))
 
-    sb = SdistBuilder(ini_file)
-    sdist_file = sb.build()
+    if 'wheel' in formats:
+        wheel_info = wheel_main(ini_file)
+    else:
+        wheel_info = None
 
-    return SimpleNamespace(wheel=wheel_info,
-                           sdist=SimpleNamespace(builder=sb, file=sdist_file))
+    if 'sdist' in formats:
+        sb = SdistBuilder(ini_file)
+        sdist_file = sb.build()
+        sdist_info = SimpleNamespace(builder=sb, file=sdist_file)
+    else:
+        sdist_info = None
+
+    return SimpleNamespace(wheel=wheel_info, sdist=sdist_info)

--- a/flit/build.py
+++ b/flit/build.py
@@ -1,0 +1,19 @@
+"""flit build - build both wheel and sdist"""
+
+import logging
+from types import SimpleNamespace
+
+from .sdist import SdistBuilder
+from .wheel import wheel_main
+
+log = logging.getLogger(__name__)
+
+def main(ini_file):
+    """Build wheel and sdist"""
+    wheel_info = wheel_main(ini_file)
+
+    sb = SdistBuilder(ini_file)
+    sdist_file = sb.build()
+
+    return SimpleNamespace(wheel=wheel_info,
+                           sdist=SimpleNamespace(builder=sb, file=sdist_file))

--- a/flit/sdist.py
+++ b/flit/sdist.py
@@ -163,6 +163,7 @@ class SdistBuilder:
                            self.srcdir)
 
         files = vcs_mod.list_tracked_files(self.srcdir)
+        log.info("Found %d files tracked in %s", len(files), vcs_mod.name)
         return sorted(filter(include_path, files))
 
     def make_setup_py(self):
@@ -242,7 +243,8 @@ class SdistBuilder:
 
         tf.close()
 
-        log.info("Built %s", target)
+        log.info("Built sdist: %s", target)
+        return target
 
 if __name__ == '__main__':
     try:

--- a/flit/upload.py
+++ b/flit/upload.py
@@ -178,9 +178,12 @@ def do_upload(file:Path, metadata:Metadata, repo_name='pypi'):
     log.info("Package is at %s/%s", repo['url'], metadata.name)
 
 
-def main(ini_path, repo_name):
+def main(ini_path, repo_name, formats=None):
     """Build and upload wheel and sdist."""
     from . import build
-    built = build.main(ini_path)
-    do_upload(built.wheel.file, built.wheel.builder.metadata, repo_name)
-    do_upload(built.sdist.file, built.sdist.builder.metadata, repo_name)
+    built = build.main(ini_path, formats=formats)
+
+    if built.wheel is not None:
+        do_upload(built.wheel.file, built.wheel.builder.metadata, repo_name)
+    if built.sdist is not None:
+        do_upload(built.sdist.file, built.sdist.builder.metadata, repo_name)

--- a/flit/upload.py
+++ b/flit/upload.py
@@ -109,15 +109,18 @@ def build_post_data(action, metadata:Metadata):
 
     return {k:v for k,v in d.items() if v}
 
-def upload_wheel(file:Path, metadata:Metadata, repo):
-    """Upload a .whl file to the PyPI server.
+def upload_file(file:Path, metadata:Metadata, repo):
+    """Upload a file to the PyPI server.
     """
     data = build_post_data('file_upload', metadata)
     data['protocol_version'] = '1'
-    data['filetype'] = 'bdist_wheel'
-    py2_support = not (metadata.requires_python or '')\
-                                .startswith(('3', '>3', '>=3'))
-    data['pyversion'] = ('py2.' if py2_support else '') + 'py3'
+    if file.suffix == '.whl':
+        data['filetype'] = 'bdist_wheel'
+        py2_support = not (metadata.requires_python or '')\
+                                    .startswith(('3', '>3', '>=3'))
+        data['pyversion'] = ('py2.' if py2_support else '') + 'py3'
+    else:
+        data['filetype'] = 'sdist'
 
     with file.open('rb') as f:
         content = f.read()
@@ -157,19 +160,27 @@ def verify(metadata:Metadata, repo_name):
     log.info('Verification succeeded')
 
 def do_upload(file:Path, metadata:Metadata, repo_name='pypi'):
-    """Upload a wheel, registering a new package if necessary.
+    """Upload a file, registering a new package if necessary.
     """
     repo = get_repository(repo_name)
     try:
-        upload_wheel(file, metadata, repo)
+        upload_file(file, metadata, repo)
     except requests.HTTPError as e:
         if e.response.status_code == 403:
             # 403 can happens if the package is not already on PyPI - try
             # registering it and uploading again.
             log.warning('Uploading forbidden; trying to register and upload again')
             register(metadata, repo)
-            upload_wheel(file, metadata, repo)
+            upload_file(file, metadata, repo)
         else:
             raise
 
     log.info("Package is at %s/%s", repo['url'], metadata.name)
+
+
+def main(ini_path, repo_name):
+    """Build and upload wheel and sdist."""
+    from . import build
+    built = build.main(ini_path)
+    do_upload(built.wheel.file, built.wheel.builder.metadata, repo_name)
+    do_upload(built.sdist.file, built.sdist.builder.metadata, repo_name)

--- a/flit/vcs/git.py
+++ b/flit/vcs/git.py
@@ -1,6 +1,8 @@
 import os
 from subprocess import check_output
 
+name = 'git'
+
 def list_tracked_files(directory):
     outb = check_output(['git', 'ls-files'], cwd=str(directory))
     return [os.fsdecode(l) for l in outb.strip().splitlines()]

--- a/flit/vcs/hg.py
+++ b/flit/vcs/hg.py
@@ -1,6 +1,8 @@
 import os
 from subprocess import check_output
 
+name = 'hg'
+
 def find_repo_root(directory):
     for p in [directory] + list(directory.parents):
         if (p / '.hg').is_dir():

--- a/flit/wheel.py
+++ b/flit/wheel.py
@@ -10,6 +10,7 @@ import os
 import re
 import sys
 import tempfile
+from types import SimpleNamespace
 
 if sys.version_info >= (3, 6):
     import zipfile
@@ -204,7 +205,7 @@ def wheel_main(ini_path, upload=False, verify_metadata=False, repo='pypi'):
 
     wheel_path = dist_dir / wb.wheel_filename
     os.replace(temp_path, str(wheel_path))
-    log.info("Wheel built: %s", wheel_path)
+    log.info("Built wheel: %s", wheel_path)
 
     if verify_metadata:
         from .upload import verify
@@ -213,3 +214,5 @@ def wheel_main(ini_path, upload=False, verify_metadata=False, repo='pypi'):
     if upload:
         from .upload import do_upload
         do_upload(wheel_path, wb.metadata, repo)
+
+    return SimpleNamespace(builder=wb, file=wheel_path)


### PR DESCRIPTION
These allow producing and uploading both wheels and sdists at the same time.

- [x] I still want to think about the naming.
- [x] Add a way to skip one format, maybe something like `flit upload --no wheel`? Should it be positive or negative?