### PR TITLE
Extract a package's summary & version via ast

### DIFF
--- a/flit/common.py
+++ b/flit/common.py
@@ -101,14 +101,14 @@ def check_version(version):
     """
     Check whether a given version string match Pep 440
 
-    Raise InvalidVersion/NoVersionError With relevant information if 
-    version is invalid. 
+    Raise InvalidVersion/NoVersionError With relevant information if
+    version is invalid.
 
     Print a warning if the version is not canonical with respect to Pep440
 
     Return whether the version is canonical with pep440
     """
-    if not version: 
+    if not version:
         raise NoVersionError('Cannot package module without a version string. '
                              'Please define a `__version__="x.y.z"` in your module.')
     if not isinstance(version, str):

--- a/tests/samples/moduleunimportable.py
+++ b/tests/samples/moduleunimportable.py
@@ -1,0 +1,8 @@
+
+"""
+A sample unimportable module
+"""
+
+raise ImportError()
+
+__version__ = "0.1"

--- a/tests/samples/modulewithconstructedversion.py
+++ b/tests/samples/modulewithconstructedversion.py
@@ -1,0 +1,4 @@
+
+"""This module has a __version__ that requires runtime interpretation"""
+
+__version__ = ".".join(["1", "2", "3"])

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -41,6 +41,11 @@ class ModuleTests(TestCase):
                                 'version': '0.1'}
                          )
 
+        info = get_info_from_module(Module('moduleunimportable', samples_dir))
+        self.assertEqual(info, {'summary': 'A sample unimportable module',
+                                'version': '0.1'}
+                         )
+
         with self.assertRaises(InvalidVersion):
             get_info_from_module(Module('invalid_version1', samples_dir))
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -46,6 +46,11 @@ class ModuleTests(TestCase):
                                 'version': '0.1'}
                          )
 
+        info = get_info_from_module(Module('modulewithconstructedversion', samples_dir))
+        self.assertEqual(info, {'summary': 'This module has a __version__ that requires runtime interpretation',
+                                'version': '1.2.3'}
+                         )
+
         with self.assertRaises(InvalidVersion):
             get_info_from_module(Module('invalid_version1', samples_dir))
 


### PR DESCRIPTION
Per discussion in https://github.com/takluyver/flit/issues/141, this POC PR extracts a package under build's version & summary via `ast`, falling back to an import if that fails (because, for example, the `__version__` is anything but a simple string assignment).

This change allows packages to be built in an environment where the package being built can't necessarily be imported.