### PR TITLE
add option to use pth file on install command

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -69,6 +69,9 @@ def main(argv=None):
     parser_install.add_argument('-s', '--symlink', action='store_true',
         help="Symlink the module/package into site packages instead of copying it"
     )
+    parser_install.add_argument('--pth', action='store_true',
+        help="Add pth entry of the module/package into site packages of copying it"
+    )
     add_shared_install_options(parser_install)
     parser_install.add_argument('--deps', choices=['all', 'production', 'develop', 'none'], default='all',
         help="Which set of dependencies to install")
@@ -126,7 +129,7 @@ def main(argv=None):
         from .install import Installer
         try:
             Installer(args.ini_file, user=args.user, python=args.python,
-                      symlink=args.symlink, deps=args.deps).install()
+                      symlink=args.symlink, deps=args.deps, pth=args.pth).install()
         except (common.NoDocstringError, common.NoVersionError) as e:
             sys.exit(e.args[0])
     elif args.subcmd == 'installfrom':

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -45,6 +45,13 @@ class InstallTests(TestCase):
                       to=str(samples_dir / 'package1'))
         assert_isfile(self.tmpdir / 'scripts' / 'pkg_script')
 
+    def test_pth_package(self):
+        Installer(samples_dir / 'package1-pkg.ini', pth=True).install()
+        assert_isfile(self.tmpdir / 'site-packages' / 'package1.pth')
+        with open(str(self.tmpdir / 'site-packages' / 'package1.pth')) as f:
+            assert f.read() == str(samples_dir)
+        assert_isfile(self.tmpdir / 'scripts' / 'pkg_script')
+
     def test_dist_name(self):
         Installer(samples_dir / 'altdistname.ini').install_directly()
         assert_isdir(self.tmpdir / 'site-packages' / 'package1')


### PR DESCRIPTION
`flit install -s` uses symlink, so this option can't work on windows.
this PR adds option using pth file to add project directory to `sys.path`.