### PR TITLE
Bring back zipfile36 as a requirement for older Pythons

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires=["requests",
     "docutils",
     "requests_download",
     "pytoml",
+    "zipfile36; python_version in '3.3 3.4 3.5'",
 ]
 requires-python=">=3"
 description-file="README.rst"


### PR DESCRIPTION
It looks like this may have been removed unintentionally when flit's own build config moved to `pyproject.toml` — it's definitely still required at runtime on Pythons < 3.6.