### PR TITLE
Escape name components for .dist-info directory

### DIFF
--- a/flit/buildapi.py
+++ b/flit/buildapi.py
@@ -2,7 +2,7 @@
 import logging
 from pathlib import Path
 
-from .common import Module, make_metadata, write_entry_points
+from .common import Module, make_metadata, write_entry_points, dist_info_name
 from .inifile import read_pkg_ini
 from .wheel import make_wheel_in, _write_wheel_file
 from .sdist import SdistBuilder
@@ -26,8 +26,8 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
     module = Module(ini_info['module'], Path.cwd())
     metadata = make_metadata(module, ini_info)
 
-    dist_version = metadata.name + '-' + metadata.version
-    dist_info = Path(metadata_directory, dist_version + '.dist-info')
+    dist_info = Path(metadata_directory,
+                     dist_info_name(metadata.name, metadata.version))
     dist_info.mkdir()
 
     supports_py2 = not (metadata.requires_python or '')\

--- a/flit/common.py
+++ b/flit/common.py
@@ -311,3 +311,8 @@ def metadata_and_module_from_ini_path(ini_path):
     metadata = make_metadata(module, ini_info)
     return metadata,module
 
+def dist_info_name(distribution, version):
+    """Get the correct name of the .dist-info folder"""
+    escaped_name = re.sub("[^\w\d.]+", "_", distribution, flags=re.UNICODE)
+    escaped_version = re.sub("[^\w\d.]+", "_", version, flags=re.UNICODE)
+    return '{}-{}.dist-info'.format(escaped_name, escaped_version)

--- a/flit/install.py
+++ b/flit/install.py
@@ -5,6 +5,7 @@ import os
 import csv
 import pathlib
 import random
+import re
 import shutil
 import site
 import sys
@@ -300,9 +301,8 @@ class Installer(object):
     def write_dist_info(self, site_pkgs):
         """Write dist-info folder, according to PEP 376"""
         metadata = common.make_metadata(self.module, self.ini_info)
-
-        dist_info = pathlib.Path(site_pkgs) / '{}-{}.dist-info'.format(
-                                            metadata.name, metadata.version)
+        dist_info = pathlib.Path(site_pkgs) / common.dist_info_name(
+                                                metadata.name, metadata.version)
         try:
             dist_info.mkdir()
         except FileExistsError:

--- a/tests/samples/altdistname.ini
+++ b/tests/samples/altdistname.ini
@@ -3,4 +3,4 @@ module=package1
 author=Sir Robin
 author-email=robin@camelot.uk
 home-page=http://github.com/sirrobin/package1
-dist-name=packagedist1
+dist-name=package-dist1

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -55,7 +55,7 @@ class InstallTests(TestCase):
     def test_dist_name(self):
         Installer(samples_dir / 'altdistname.ini').install_directly()
         assert_isdir(self.tmpdir / 'site-packages' / 'package1')
-        assert_isdir(self.tmpdir / 'site-packages' / 'packagedist1-0.1.dist-info')
+        assert_isdir(self.tmpdir / 'site-packages' / 'package_dist1-0.1.dist-info')
 
     def test_entry_points(self):
         Installer(samples_dir / 'entrypoints_valid.ini').install_directly()

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -7,7 +7,7 @@ from unittest import skipIf
 import zipfile
 
 import pytest
-from testpath import assert_isfile
+from testpath import assert_isfile, assert_isdir
 
 from flit.wheel import wheel_main, WheelBuilder
 from flit.inifile import EntryPointsConflict
@@ -39,7 +39,10 @@ def test_wheel_package():
 def test_dist_name():
     clear_samples_dist()
     wheel_main(samples_dir / 'altdistname.ini')
-    assert_isfile(samples_dir / 'dist/packagedist1-0.1-py2.py3-none-any.whl')
+    res = samples_dir / 'dist/package_dist1-0.1-py2.py3-none-any.whl'
+    assert_isfile(res)
+    with unpack(res) as td:
+        assert_isdir(Path(td, 'package_dist1-0.1.dist-info'))
 
 def test_entry_points():
     clear_samples_dist()


### PR DESCRIPTION
The .dist-info folder should be like `pandoc_attributes-0.1.7.dist-info`, not `pandoc-attributes-0.1.7.dist-info`, so that it's unambiguous which bit is distribution name and which bit is version number.

I'm not sure the rules are clearly stated anywhere, but I've applied the same escaping PEP 427 specifies for wheel filenames.

Closes gh-149