### PR TITLE
Fix the numbering in Readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ or as a directory — and you want to distribute it.
 
        python3 -m pip install flit
 
-2. Run ``flit init`` to create a ``pyproject.toml`` file. It will look something
+3. Run ``flit init`` to create a ``pyproject.toml`` file. It will look something
    like this:
 
    .. code-block:: ini


### PR DESCRIPTION
The steps under `Usage` section were numbered as: 1,2,2,4.
Updated that to 1,2,3,4.