### PR TITLE
Remove subcommands: wheel, sdist, register

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -88,10 +88,6 @@ def main(argv=None):
         help="Prepare flit.ini for a new package"
     )
 
-    subparsers.add_parser('register',
-        help="register a package on PyPI without uploading any files"
-    )
-
     args = ap.parse_args(argv)
 
     cf = args.ini_file
@@ -148,11 +144,6 @@ def main(argv=None):
     elif args.subcmd == 'installfrom':
         from .installfrom import installfrom
         sys.exit(installfrom(args.location, user=args.user, python=args.python))
-    elif args.subcmd == 'register':
-        log.warning("'flit register' is deprecated. Use 'flit publish' directly.")
-        from .upload import register
-        meta, mod = common.metadata_and_module_from_ini_path(args.ini_file)
-        register(meta, args.repository)
     elif args.subcmd == 'init':
         from .init import TerminalIniter
         TerminalIniter().initialise()

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -43,10 +43,6 @@ def main(argv=None):
           help="Verify the package metadata with the PyPI server"
     )
 
-    parser_sdist = subparsers.add_parser('sdist',
-         help="Build a source distribution (.tar.gz)",
-    )
-
     parser_build = subparsers.add_parser('build',
         help="Build wheel and sdist",
     )
@@ -119,14 +115,6 @@ def main(argv=None):
                      repo=args.repository)
         except common.ProblemInModule as e:
             sys.exit(e.args[0])
-    elif args.subcmd == 'sdist':
-        log.warning("'flit sdist' is deprecated: use 'flit build'.")
-        from .sdist import SdistBuilder
-        try:
-            SdistBuilder(args.ini_file).build()
-        except common.VCSError as e:
-            sys.exit(str(e))
-
     elif args.subcmd == 'build':
         from .build import main
         main(args.ini_file, formats=set(args.format or []))

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -33,16 +33,6 @@ def main(argv=None):
     ap.add_argument('--logo', action='store_true', help=argparse.SUPPRESS)
     subparsers = ap.add_subparsers(title='subcommands', dest='subcmd')
 
-    parser_wheel = subparsers.add_parser('wheel',
-        help="Build a wheel package",
-    )
-    parser_wheel.add_argument('--upload', action='store_true',
-          help="Upload the built wheel to PyPI"
-    )
-    parser_wheel.add_argument('--verify-metadata', action='store_true',
-          help="Verify the package metadata with the PyPI server"
-    )
-
     parser_build = subparsers.add_parser('build',
         help="Build wheel and sdist",
     )
@@ -106,16 +96,7 @@ def main(argv=None):
         print(clogo.format(version=__version__))
         sys.exit(0)
 
-    if args.subcmd == 'wheel':
-        log.warning("'flit wheel' is deprecated: use 'flit build'.")
-        from .wheel import wheel_main
-        try:
-            wheel_main(args.ini_file, upload=args.upload,
-                     verify_metadata=args.verify_metadata,
-                     repo=args.repository)
-        except common.ProblemInModule as e:
-            sys.exit(e.args[0])
-    elif args.subcmd == 'build':
+    if args.subcmd == 'build':
         from .build import main
         main(args.ini_file, formats=set(args.format or []))
     elif args.subcmd == 'publish':

--- a/flit/upload.py
+++ b/flit/upload.py
@@ -232,19 +232,6 @@ def upload_file(file:Path, metadata:Metadata, repo):
                         )
     resp.raise_for_status()
 
-def register(metadata:Metadata, repo):
-    """Register a new release with the PyPI server.
-    """
-
-    if not isinstance(repo, dict):
-        repo = get_repository(repo)
-    data = build_post_data('submit', metadata)
-    resp = requests.post(repo['url'], data=data,
-                         auth=(repo['username'], repo['password'])
-                        )
-    resp.raise_for_status()
-    log.info('Registered %s with PyPI', metadata.name)
-
 def verify(metadata:Metadata, repo_name):
     """Verify the metadata with the PyPI server.
     """

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -4,10 +4,10 @@ import sys
 def test_flit_help():
     p = Popen([sys.executable, '-m', 'flit', '--help'], stdout=PIPE, stderr=STDOUT)
     out, _ = p.communicate()
-    assert 'Build a wheel' in out.decode('utf-8', 'replace')
+    assert 'Build wheel' in out.decode('utf-8', 'replace')
 
 def test_flit_usage():
     p = Popen([sys.executable, '-m', 'flit'], stdout=PIPE, stderr=STDOUT)
     out, _ = p.communicate()
-    assert 'Build a wheel' in out.decode('utf-8', 'replace')
+    assert 'Build wheel' in out.decode('utf-8', 'replace')
     assert p.poll() == 1

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -18,16 +18,6 @@ repo_settings = {'url': upload.PYPI,
                 }
 
 @responses.activate
-def test_register():
-    responses.add(responses.POST, upload.PYPI, status=200)
-
-    meta, mod = common.metadata_and_module_from_ini_path(samples_dir / 'module1-pkg.ini')
-    with patch('flit.upload.get_repository', return_value=repo_settings):
-        upload.register(meta, 'pypi')
-
-    assert len(responses.calls) == 1
-
-@responses.activate
 def test_verify():
     responses.add(responses.POST, upload.PYPI, status=200)
 
@@ -45,27 +35,6 @@ def test_upload():
         wheel.wheel_main(samples_dir / 'module1-pkg.ini', upload='pypi')
 
     assert len(responses.calls) == 1
-
-@responses.activate
-def test_upload_registers():
-    with patch('flit.upload.register') as register_mock:
-        def upload_callback(request):
-            status = 200 if register_mock.called else 403
-            return (status, {}, '')
-
-        old_pypi = "https://pypi.python.org/pypi"
-        responses.add_callback(responses.POST, old_pypi,
-                               callback=upload_callback)
-
-        repo = repo_settings.copy()
-        repo['url'] = old_pypi
-        repo['is_warehouse'] = False
-
-        with patch('flit.upload.get_repository', return_value=repo):
-            wheel.wheel_main(samples_dir / 'module1-pkg.ini', upload='pypi')
-
-    assert len(responses.calls) == 2
-    assert register_mock.call_count == 1
 
 pypirc1 = """
 [distutils]


### PR DESCRIPTION
These were deprecated in 0.13.

* *register* doesn't work with Warehouse, and since legacy PyPI no longer accepts uploads, it doesn't seem important to keep it. Users should now just upload packages directly.
* `flit build` now produces wheels and sdists, so the separate commands for them are no longer needed.