### PR TITLE
Project URLs

### DIFF
--- a/doc/history.rst
+++ b/doc/history.rst
@@ -1,6 +1,13 @@
 Release history
 ===============
 
+Version 0.14
+------------
+
+- Multiple links (e.g. documentation, bug tracker) can now be specified in a
+  new :ref:`[tool.flit.metadata.urls] section <pyproject_toml_urls>` of
+  ``pyproject.toml``.
+
 Version 0.13
 ------------
 

--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -115,6 +115,25 @@ Here's the full metadata section from flit itself:
         "Topic :: Software Development :: Libraries :: Python Modules",
     ]
 
+.. _pyproject_toml_urls:
+
+URLs subsection
+~~~~~~~~~~~~~~~
+
+Your project's page on `pypi.org <https://pypi.org/>`_ can show a number of
+links, in addition to the required ``home-page`` URL described above. You can
+point people to documentation or a bug tracker, for example.
+
+This section is called ``[tool.flit.metadata.urls]`` in the file. You can use
+any names inside it. Here it is for flit:
+
+.. code-block:: toml
+
+  [tool.flit.metadata.urls]
+  Documentation = "https://flit.readthedocs.io/en/latest/"
+
+.. versionadded:: 0.14
+
 .. _pyproject_toml_scripts:
 
 Scripts section

--- a/flit/common.py
+++ b/flit/common.py
@@ -277,6 +277,9 @@ class Metadata:
         for req in self.requires_dist:
             fp.write('Requires-Dist: {}\n'.format(req))
 
+        for url in self.project_urls:
+            fp.write('Project-URL: {}\n'.format(url))
+
         if self.description is not None:
             fp.write('\n' + self.description + '\n')
 

--- a/flit/inifile.py
+++ b/flit/inifile.py
@@ -198,6 +198,12 @@ def _prep_metadata(md_sect, path):
             log.warning(stream.getvalue())
         md_dict['description'] =  raw_desc
 
+    if 'urls' in md_sect:
+        project_urls = md_dict['project_urls'] = []
+        for label, url in md_sect.pop('urls').items():
+            project_urls.append("{}, {}".format(label, url))
+            print("Found URL for", label)
+
     for key, value in md_sect.items():
         if key in {'description-file', 'module'}:
             continue

--- a/flit/inifile.py
+++ b/flit/inifile.py
@@ -202,7 +202,6 @@ def _prep_metadata(md_sect, path):
         project_urls = md_dict['project_urls'] = []
         for label, url in md_sect.pop('urls').items():
             project_urls.append("{}, {}".format(label, url))
-            print("Found URL for", label)
 
     for key, value in md_sect.items():
         if key in {'description-file', 'module'}:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,5 +25,8 @@ classifiers=["Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
+[tool.flit.metadata.urls]
+Documentation = "https://flit.readthedocs.io/en/latest/"
+
 [tool.flit.scripts]
 flit = "flit:main"

--- a/tests/samples/module1-pkg.toml
+++ b/tests/samples/module1-pkg.toml
@@ -7,3 +7,6 @@ author = "Sir Robin"
 author-email = "robin@camelot.uk"
 home-page = "http://github.com/sirrobin/module1"
 description-file = "EG_README.rst"
+
+[tool.flit.metadata.urls]
+Documentation = "https://example.com/module1"


### PR DESCRIPTION
Add the ability to specify multiple URLs with names, like this:

```toml
[tool.flit.metadata.urls]
Documentation = "https://flit.readthedocs.io/en/latest/"
```

Closes #116.