### PR TITLE
Official support for markdown and plain text descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 /tests/samples/dist/
 /htmlcov/
 /.coverage
+/.pytest_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.5"
   - "3.4"
 install:
+  - pip install --upgrade pytest
   - pip install -r requirements-test.txt
   - pip install codecov
 script: py.test --cov=flit

--- a/doc/history.rst
+++ b/doc/history.rst
@@ -4,6 +4,10 @@ Release history
 Version 0.14
 ------------
 
+- The description file may now be written in reStructuredText, Markdown or
+  plain text. The file extension should indicate which of these formats it is
+  (``.rst``, ``.md`` or ``.txt``). Previously, only reStructuredText was
+  officially supported.
 - Multiple links (e.g. documentation, bug tracker) can now be specified in a
   new :ref:`[tool.flit.metadata.urls] section <pyproject_toml_urls>` of
   ``pyproject.toml``.

--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -71,11 +71,11 @@ dev-requires
   These are not (yet) encoded in the wheel, but are used when doing
   ``flit install``.
 description-file
-  A path (relative to the .ini file) to a file containing a longer description
+  A path (relative to the .toml file) to a file containing a longer description
   of your package to show on PyPI. This should be written in `reStructuredText
-  <http://docutils.sourceforge.net/docs/user/rst/quickref.html>`_, if your long
-  description is not valid reStructuredText, a warning will be printed,
-  and it will be interpreted as plain text on PyPI.
+  <http://docutils.sourceforge.net/docs/user/rst/quickref.html>`_, Markdown or
+  plain text, and the filename should have the appropriate extension
+  (``.rst``, ``.md`` or ``.txt``).
 classifiers
   A list of `Trove classifiers <https://pypi.python.org/pypi?%3Aaction=list_classifiers>`_.
 requires-python

--- a/flit/common.py
+++ b/flit/common.py
@@ -212,6 +212,7 @@ class Metadata:
     keywords = None
     download_url = None
     requires_python = None
+    description_content_type = None
 
     platform = ()
     supported_platform = ()
@@ -224,8 +225,9 @@ class Metadata:
     requires_dist = ()
     obsoletes_dist = ()
     requires_external = ()
+    provides_extra = ()
 
-    metadata_version="1.2"
+    metadata_version="2.1"
 
     # this is part of metadata spec 2, we are using it for installation but it
     # doesn't actually get written to the metadata file
@@ -244,7 +246,7 @@ class Metadata:
         return n.lower().replace('-', '_')
 
     def write_metadata_file(self, fp):
-        """Write out metadata in the 1.x format (email like)"""
+        """Write out metadata in the email headers format"""
         fields = [
             'Metadata-Version',
             'Name',
@@ -260,6 +262,7 @@ class Metadata:
             'Maintainer',
             'Maintainer-email',
             'Requires-Python',
+            'Description-Content-Type',
         ]
 
         for field in fields:
@@ -279,6 +282,9 @@ class Metadata:
 
         for url in self.project_urls:
             fp.write('Project-URL: {}\n'.format(url))
+
+        for extra in self.provides_extra:
+            fp.write('Provides-Extra: {}\n'.format(extra))
 
         if self.description is not None:
             fp.write('\n' + self.description + '\n')

--- a/tests/samples/bad-description-ext.toml
+++ b/tests/samples/bad-description-ext.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = ["flit"]
+
+[tool.flit.metadata]
+module = "module1"
+author = "Sir Robin"
+author-email = "robin@camelot.uk"
+home-page = "http://github.com/sirrobin/module1"
+description-file = "module1.py"  # WRONG

--- a/tests/test_inifile.py
+++ b/tests/test_inifile.py
@@ -48,4 +48,4 @@ def test_description_file():
     info = read_pkg_ini(samples_dir / 'package1-pkg.ini')
     assert info['metadata']['description'] == \
         "Sample description for test.\n"
-
+    assert info['metadata']['description_content_type'] == 'text/x-rst'

--- a/tests/test_inifile.py
+++ b/tests/test_inifile.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 
 import pytest
@@ -49,3 +50,9 @@ def test_description_file():
     assert info['metadata']['description'] == \
         "Sample description for test.\n"
     assert info['metadata']['description_content_type'] == 'text/x-rst'
+
+def test_bad_description_extension(caplog):
+    info = read_pkg_ini(samples_dir / 'bad-description-ext.toml')
+    assert info['metadata']['description_content_type'] is None
+    assert any((r.levelno == logging.WARN and "Unknown extension" in r.msg)
+                for r in caplog.records)


### PR DESCRIPTION
Fixes #166.

Until recently, PyPI only supported rst descriptions, falling back to plain text if the rst was invalid. Now a new metadata field `Description-Content-Type` lets us specify whether the description is rst, markdown or plain text. This new code uses that, picking the content type based on the file extension (`.rst`, `.md` or `.txt`). If the extension is something else, Flit will warn the user and leave the field unset, so it's up to PyPI what to do with it.

Markdown support has been a secret feature of Flit for some time, by using pandoc to convert markdown to rst (thanks @Carreau!). This makes it an official feature, and gets rid of the code to call pandoc, since PyPI can now handle markdown natively.