### PR TITLE
Only install reqs in sys.executable if needed

### DIFF
--- a/tests/samples/requires-requests.toml
+++ b/tests/samples/requires-requests.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["flit"]
+
+[tool.flit.metadata]
+module = "module1"
+author = "Sir Robin"
+author-email = "robin@camelot.uk"
+home-page = "http://github.com/sirrobin/module1"
+description-file = "EG_README.rst"
+requires = ["requests"]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -107,6 +107,16 @@ class InstallTests(TestCase):
                       to=str(samples_dir / 'package1'))
         assert_isfile(self.tmpdir / 'scripts2' / 'pkg_script')
 
+    def test_install_requires(self):
+        ins = Installer(samples_dir / 'requires-requests.toml',
+                        user=False, python='mock_python')
+
+        with MockCommand('mock_python') as mockpy:
+            ins.install_requirements()
+        calls = mockpy.get_calls()
+        assert len(calls) == 1
+        assert calls[0]['argv'][1:5] == ['-m', 'pip', 'install', '-r']
+
 def test_requires_dist_to_pip_requirement():
     rd = 'pathlib2 (>=2.3); python_version == "2.7"'
     assert _requires_dist_to_pip_requirement(rd) == \


### PR DESCRIPTION
In most cases, we can get the docstring and version number from the AST, so we don't need the package to be importable. If getting that info fails with ImportError, then we install the requirements before trying again.

Also, when we install directly (for --symlink or --pth-file), ensure that the requirements are installed to the target environment.

Closes gh-165
Closes gh-164