### PR TITLE
Allow reading project version from source control

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -4,7 +4,7 @@ import logging
 import pathlib
 import sys
 
-from . import common
+from . import common, errors
 from .log import enable_colourful_output
 
 __version__ = '1.0'
@@ -105,7 +105,7 @@ def main(argv=None):
         from .build import main
         try:
             main(args.ini_file, formats=set(args.format or []))
-        except(common.NoDocstringError) as e:
+        except(errors.NoDocstringError) as e:
             sys.exit(e.args[0])
     elif args.subcmd == 'publish':
         from .upload import main
@@ -117,7 +117,7 @@ def main(argv=None):
             Installer(args.ini_file, user=args.user, python=args.python,
                       symlink=args.symlink, deps=args.deps, extras=args.extras,
                       pth=args.pth_file).install()
-        except (common.NoDocstringError, common.NoVersionError) as e:
+        except (errors.NoDocstringError, errors.NoVersionError) as e:
             sys.exit(e.args[0])
     elif args.subcmd == 'installfrom':
         from .installfrom import installfrom

--- a/flit/common.py
+++ b/flit/common.py
@@ -4,10 +4,15 @@ import hashlib
 from importlib.machinery import SourceFileLoader
 import logging
 from pathlib import Path
+import re
+
+from .errors import (
+    NoDocstringError, NoVersionError,
+    VCSError,
+    InvalidVersion,
+)
 
 log = logging.getLogger(__name__)
-
-import re
 
 class Module(object):
     """This represents the module/package that we are going to distribute
@@ -36,18 +41,6 @@ class Module(object):
         else:
             return self.path
 
-class ProblemInModule(ValueError): pass
-class NoDocstringError(ProblemInModule): pass
-class NoVersionError(ProblemInModule): pass
-class InvalidVersion(ProblemInModule): pass
-
-class VCSError(Exception):
-    def __init__(self, msg, directory):
-        self.msg = msg
-        self.directory = directory
-
-    def __str__(self):
-        return self.msg + ' ({})'.format(self.directory)
 
 
 @contextmanager

--- a/flit/errors.py
+++ b/flit/errors.py
@@ -1,0 +1,12 @@
+class ProblemInModule(ValueError): pass
+class NoDocstringError(ProblemInModule): pass
+class NoVersionError(ProblemInModule): pass
+class InvalidVersion(ProblemInModule): pass
+
+class VCSError(Exception):
+    def __init__(self, msg, directory):
+        self.msg = msg
+        self.directory = directory
+
+    def __str__(self):
+        return self.msg + ' ({})'.format(self.directory)

--- a/flit/sdist.py
+++ b/flit/sdist.py
@@ -10,7 +10,7 @@ from pprint import pformat
 import tarfile
 
 from flit import common, inifile
-from flit.common import VCSError
+from flit.errors import VCSError
 from flit.vcs import identify_vcs
 
 log = logging.getLogger(__name__)

--- a/flit/validate.py
+++ b/flit/validate.py
@@ -7,7 +7,7 @@ import re
 import requests
 import sys
 
-from .common import InvalidVersion
+from .errors import InvalidVersion
 
 log = logging.getLogger(__name__)
 

--- a/flit/vcs/__init__.py
+++ b/flit/vcs/__init__.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from flit.common import VCSError
+from flit.errors import VCSError
 from . import hg
 from . import git
 

--- a/flit/vcs/__init__.py
+++ b/flit/vcs/__init__.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from setuptools_scm import get_version
+
 from flit.errors import VCSError
 from . import hg
 from . import git
@@ -13,3 +15,12 @@ def identify_vcs(directory: Path):
             return hg
 
     raise VCSError("Directory does not appear to be in a VCS", directory)
+
+def get_version_from_scm(scm_dir: Path) -> str:
+    try:
+        return get_version(scm_dir)
+    except LookupError as exc:
+        raise VCSError(
+            'Failed to get version from source control: {}'.
+            format(str(exc))
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 requires = ["intreehooks", "requests", "docutils", "pytoml",
-            "zipfile36; python_version in '3.3 3.4 3.5'",]
+            "zipfile36; python_version in '3.3 3.4 3.5'",
+            "setuptools_scm",
+]
 build-backend = "intreehooks:loader"
 
 [tool.intreehooks]
@@ -16,6 +18,7 @@ requires=["requests",
     "requests_download",
     "pytoml",
     "zipfile36; python_version in '3.3 3.4 3.5'",
+    "setuptools_scm",
 ]
 requires-python=">=3"
 description-file="README.rst"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,4 @@ pytoml
 pytest>=2.7.3
 pytest-warnings
 pytest-cov
+setuptools_scm

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,9 +2,10 @@ from pathlib import Path
 from unittest import TestCase
 import pytest
 
-from flit.common import (Module, get_info_from_module, InvalidVersion, NoVersionError,
+from flit.common import (Module, get_info_from_module,
      check_version, normalize_file_permissions
 )
+from flit.errors import InvalidVersion, NoVersionError
 
 samples_dir = Path(__file__).parent / 'samples'
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,5 +1,5 @@
 import pytest
-from flit.common import InvalidVersion
+from flit.errors import InvalidVersion
 from flit import validate as fv
 
 def test_validate_entrypoints():


### PR DESCRIPTION
I've promptly integrated setuptools_scm with flit to achieve the ability to keep a version in Git tag.

This is going to be used in python/core-workflow#286