### PR TITLE
Fix warnings when building the documentation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ install:
   - pip install --upgrade pytest
   - pip install -r requirements-test.txt
   - pip install codecov
-script: py.test --cov=flit
+script:
+  - py.test --cov=flit
+  - sphinx-build -b html -d _build/doctrees doc _build/html
 after_success: codecov
 sudo: false

--- a/doc/upload.rst
+++ b/doc/upload.rst
@@ -60,7 +60,7 @@ Using environment variables
 You can specify a server to upload to with :envvar:`FLIT_INDEX_URL`, and
 pass credentials with :envvar:`FLIT_USERNAME` and :envvar:`FLIT_PASSWORD`.
 Environment variables take precedence over the config file, except if you use
-the :option:`--repository` option to explicitly pick a server from the config file.
+the :option:`flit --repository` option to explicitly pick a server from the config file.
 
 This can make it easier to automate uploads, for example to release packages
 from a continuous integration job.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,4 @@ pytoml
 pytest>=2.7.3
 pytest-warnings
 pytest-cov
+sphinx


### PR DESCRIPTION
Fix the warning related to `--repository` option.
Add sphinx to requirements-test.
Run `make html` as part of travis CI.

Closes https://github.com/takluyver/flit/issues/189