### PR TITLE
Pytest-Warning now in core Pytest:

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ test = [
 	"testpath",
 	"responses",
 	"pytest>=2.7.3",
-	"pytest-warnings",
 	"pytest-cov",
 ]
 doc = [

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,5 +6,4 @@ docutils
 zipfile36
 pytoml
 pytest>=2.7.3
-pytest-warnings
 pytest-cov


### PR DESCRIPTION

    $ py.test --cov=flit
    /home/.../site-packages/pytest_warnings/__init__.py:44:
    UserWarning: pytest-warnings plugin was introduced in core pytest on 3.1, please uninstall pytest-warnings