### PR TITLE
Don’t check for toml file in “installfrom”

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -82,8 +82,11 @@ def main(argv=None):
     args = ap.parse_args(argv)
 
     cf = args.ini_file
-    if args.subcmd != 'init' and cf == pathlib.Path('pyproject.toml')\
-            and not cf.is_file():
+    if (
+        args.subcmd not in {'init', 'installfrom'}
+        and cf == pathlib.Path('pyproject.toml')
+        and not cf.is_file()
+    ):
         # Fallback to flit.ini if it's present
         cf_ini = pathlib.Path('flit.ini')
         if cf_ini.is_file():


### PR DESCRIPTION
Fixes #158