### PR TITLE
Fix #175 and add type annotation to arg. of `get_module_info`

### DIFF
--- a/flit/common.py
+++ b/flit/common.py
@@ -97,7 +97,7 @@ def get_docstring_and_version_via_import(target):
     version = m.__dict__.get('__version__', None)
     return docstring, version
 
-def get_info_from_module(target):
+def get_info_from_module(target: Module):
     """Load the module/package, get its docstring and __version__
     """
     log.debug("Loading module %s", target.file)
@@ -111,9 +111,9 @@ def get_info_from_module(target):
         docstring, version = get_docstring_and_version_via_import(target)
 
     if (not docstring) or not docstring.strip():
-        raise NoDocstringError('Flit cannot package module without docstring, or empty docstring. '
-                               'Please add a docstring to your module.')
-
+        raise NoDocstringError('Flit cannot package module without docstring, '
+                'or empty docstring. Please add a docstring to your module '
+                '({}).'.format(target.file))
 
     version = check_version(version)
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -5,7 +5,7 @@ import sys
 from tempfile import TemporaryDirectory
 from testpath import assert_isdir, MockCommand
 
-from flit import build
+from flit import build, common
 
 samples_dir = Path(__file__).parent / 'samples'
 
@@ -47,12 +47,6 @@ def test_build_module_no_docstring():
 
         with MockCommand('git', LIST_FILES_TEMPLATE.format(
                 python=sys.executable, module='no_docstring.py')):
-            with pytest.raises(ValueError) as exc_info:
+            with pytest.raises(common.NoDocstringError) as exc_info:
                 build.main(pyproject)
-            errmsg_head, errmsg_tail = str(exc_info.value).split('(')
-            errmsg_head_shouldbe = ('Flit cannot package module without '
-            'docstring, or empty docstring. Please add a docstring to your '
-            'module ')
-            errmsg_tail_shouldbe = str(Path(td, 'no_docstring.py')) + ').'
-            assert errmsg_head == errmsg_head_shouldbe
-            assert errmsg_tail == errmsg_tail_shouldbe
+            assert 'no_docstring.py' in str(exc_info.value)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -49,6 +49,7 @@ def test_build_module_no_docstring():
                 python=sys.executable, module='no_docstring.py')):
             with pytest.raises(ValueError) as exc_info:
                 build.main(pyproject)
-            assert str(
-                exc_info.value) == ('Flit cannot package module without docstring, or empty docstring. '
-                                    'Please add a docstring to your module.')
+            assert str(exc_info.value).startswith('Flit cannot package module '
+                    'without docstring, or empty docstring. Please add a '
+                    'docstring to your module')
+            assert 'no_docstring.py' in str(exc_info.value)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -49,7 +49,10 @@ def test_build_module_no_docstring():
                 python=sys.executable, module='no_docstring.py')):
             with pytest.raises(ValueError) as exc_info:
                 build.main(pyproject)
-            assert str(exc_info.value).startswith('Flit cannot package module '
-                    'without docstring, or empty docstring. Please add a '
-                    'docstring to your module')
-            assert 'no_docstring.py' in str(exc_info.value)
+            errmsg_head, errmsg_tail = str(exc_info.value).split('(')
+            errmsg_head_shouldbe = ('Flit cannot package module without '
+            'docstring, or empty docstring. Please add a docstring to your '
+            'module ')
+            errmsg_tail_shouldbe = str(Path(td, 'no_docstring.py')) + ').'
+            assert errmsg_head == errmsg_head_shouldbe
+            assert errmsg_tail == errmsg_tail_shouldbe


### PR DESCRIPTION
- Add module name to error about missing docstring.
- Add type annotation to function common.get_module_info signature
- Adapt tests to the new error message.