### PR TITLE
py.test -> pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ install:
   - pip install --upgrade pytest
   - pip install -r requirements-test.txt
   - pip install codecov
-script: py.test --cov=flit
+script: pytest --cov=flit
 after_success: codecov
 sudo: false

--- a/README.rst
+++ b/README.rst
@@ -81,4 +81,4 @@ To install the development version of Flit from Github::
 You may want to use the ``--symlink`` or ``--pth-file`` options so you can test
 changes without reinstalling it.
 
-To run the tests, run ``py.test``.
+To run the tests, run ``pytest``.


### PR DESCRIPTION
py.test is not recommended since pytest v3.0 (see https://github.com/pytest-dev/pytest/issues/1629)