### PR TITLE
Bugfix for building sdists in Mercurial repos

### DIFF
--- a/flit/vcs/hg.py
+++ b/flit/vcs/hg.py
@@ -10,6 +10,7 @@ def find_repo_root(directory):
 
 def _repo_paths_to_directory_paths(paths, directory):
     # 'hg status' gives paths from repo root, which may not be our directory.
+    directory = directory.resolve()
     repo = find_repo_root(directory)
     if directory != repo:
         directory_in_repo = str(directory.relative_to(repo)) + os.sep


### PR DESCRIPTION
find_repo_root's parent-directory-walking behaviour doesn't behave quite as expected when called with a relative path; if called in any directory except the root of the repo it would return None, which calling code did not expect.