### PR TITLE
Allow specifying encodings

### DIFF
--- a/flit/common.py
+++ b/flit/common.py
@@ -69,7 +69,8 @@ def get_docstring_and_version_via_ast(target):
     extracted by parsing its AST.
     """
     # read as bytes to enable custom encodings
-    node = ast.parse(target.file.read_bytes())
+    with target.file.open('rb') as f:
+        node = ast.parse(f.read())
     for child in node.body:
         # Only use the version from the given module if it's a simple
         # string assignment to __version__

--- a/flit/common.py
+++ b/flit/common.py
@@ -68,8 +68,8 @@ def get_docstring_and_version_via_ast(target):
     Return a tuple like (docstring, version) for the given module,
     extracted by parsing its AST.
     """
-    with target.file.open() as f:
-        node = ast.parse(f.read())
+    # read as bytes to enable custom encodings
+    node = ast.parse(target.file.read_bytes())
     for child in node.body:
         # Only use the version from the given module if it's a simple
         # string assignment to __version__


### PR DESCRIPTION
This e.g. allows using [future-fstrings](https://github.com/asottile/future-fstrings), which I’d like to use in flying-sheep/get_version#3

You can check that this works via:

```py
#!/usr/bin/env python3.5
import ast
st = ast.parse(b"# coding: future-fstrings\nprint(f'hi {ast}')")
exec(compile(st, filename="", mode="exec"))
# hi <module 'ast' from '/usr/lib64/python3.5/ast.py'>
```