### PR TITLE
Travis CI: 'sudo' tag is now deprecated in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
   include:
     - python: "3.7"
       dist: xenial
-      sudo: true
 
 install:
   - pip install --upgrade pip
@@ -18,4 +17,3 @@ install:
   - pip install codecov
 script: pytest --cov=flit
 after_success: codecov
-sudo: false


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)