### PR TITLE
Add tox config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 /htmlcov/
 /.coverage
 /.pytest_cache
+/.tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py34,py35,py36,py37
+isolated_build = True
+
+[testenv]
+deps =
+    pytest
+    pytest-cov
+    testpath
+    requests_download
+    responses
+commands =
+    pytest


### PR DESCRIPTION
Per discussion in https://github.com/takluyver/flit/issues/231, this PR introduces config for tox that allows running flit's unit test suite against multiple Python interpreters outside of the context of GitHub's CI.