### PR TITLE
Phrase encoding support more neutrally

### DIFF
--- a/doc/history.rst
+++ b/doc/history.rst
@@ -6,7 +6,7 @@ Version 1.3
 
 - Fix for building sdists from a subdirectory in a Mercurial repository
   (:ghpull:`233`).
-- Fix for getting the docstring and version from modules using encoding hacks
+- Fix for getting the docstring and version from modules defining their encoding
   (:ghpull:`239`).
 - Fix for installing packages with ``flit installfrom`` (:ghpull:`221`).
 - Packages with requirements no longer get a spurious ``Provides-Extra: .none``


### PR DESCRIPTION
[PEP 263](https://www.python.org/dev/peps/pep-0263/) support isn’t just about hacks, even though I think that using no normal encoding but utf-8 is wise.