### PR TITLE
Add "flit info --version" command

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -79,6 +79,14 @@ def main(argv=None):
         help="Prepare pyproject.toml for a new package"
     )
 
+    parser_info = subparsers.add_parser('info',
+        help="Retrieve metadata information from the project",
+    )
+    parser_info.add_argument(
+        '--version', default=False, action='store_true', dest='show_version',
+        help="Print the version number of the project to stdout"
+    )
+
     args = ap.parse_args(argv)
 
     cf = args.ini_file
@@ -98,6 +106,11 @@ def main(argv=None):
     enable_colourful_output(logging.DEBUG if args.debug else logging.INFO)
 
     log.debug("Parsed arguments %r", args)
+
+    if args.subcmd == 'info' and args.show_version:
+        from .info import get_version
+        print(get_version(args.ini_file))
+        sys.exit(0)
 
     if args.logo:
         from .logo import clogo

--- a/flit/info.py
+++ b/flit/info.py
@@ -1,0 +1,20 @@
+"""
+This module contains code for the "info" subcommand
+"""
+
+
+def get_version(ini_path):
+    # type: (str) -> str
+    """
+    This will return the package version as a string.
+
+    :param ini_path: The filename of the main config-file
+        (flit.ini/pyproject.toml)
+    """
+    from . import inifile
+    from .common import Module, make_metadata
+    ini_info = inifile.read_pkg_ini(ini_path)
+    module = Module(ini_info['module'], ini_path.parent)
+    metadata = make_metadata(module, ini_info)
+    output = metadata.version
+    return output

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -11,3 +11,12 @@ def test_flit_usage():
     out, _ = p.communicate()
     assert 'Build wheel' in out.decode('utf-8', 'replace')
     assert p.poll() == 1
+
+def test_flit_version():
+    import flit
+    version = flit.__version__
+
+    p = Popen([sys.executable, '-m', 'flit', 'info', '--version'],
+               stdout=PIPE, stderr=STDOUT)
+    out, _ = p.communicate()
+    assert out.decode('utf-8', 'replace').strip() == version


### PR DESCRIPTION
This PR adds a new subcommand `info` with the argument `--version`.

Calling `flit info --version` will simply print the package version number to stdout. As the version number is missing in `pyproject.toml` when using `flit`, this command allows external tools to easily access the projects version number.

I did not implement this as `flit --version` as that woulc conflict with the existing flag. Having is as subcommand also makes it a bit more expressive. This PR adds the new subcommand "info" which could serve as a container for additional "informational" commands.

Questions to the maintainer(s):

I also - out of habit - added a type annotation. To be on the safe side, I used the Python2 syntax. But personally I prefer the Python 3 syntax. What is your position on this? If it is OK with you I will switch to the Py3 syntax.

Unrelated to this PR, I will also quickly refactor the subcommands. This will be a fairly big change and might trigger some discussion. How do hold discussions? Do you have a mailing-list? A IRC channel? Or should I simply add an issue & PR in "WIP" status and use GitHub comments for discussion?