### PR TITLE
Add missing doc dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ test = [
 	"pytest-cov",
 ]
 doc = [
+	"sphinx",
+	"sphinxcontrib_github_alt",
 	"pygments-github-lexers",  # TOML highlighting
 ]
 installfrom = [


### PR DESCRIPTION
I had to add these to make the docs build work.

These instructions don't give a dev env where the docs can be generated locally:
https://github.com/takluyver/flit#development

I found this option:
```
flit install --deps all
```
Maybe recomment that to hack on `flit`?