### PR TITLE
Fix CI error on test_misspelled_key

### DIFF
--- a/tests/test_inifile.py
+++ b/tests/test_inifile.py
@@ -40,7 +40,7 @@ def test_misspelled_key():
     with pytest.raises(ConfigError) as e_info:
         read_pkg_ini(samples_dir / 'misspelled-key.ini')
 
-    assert 'description-file' in str(e_info)
+    assert 'scription-file' in str(e_info.value)
 
 def test_description_file():
     info = read_pkg_ini(samples_dir / 'package1-pkg.ini')

--- a/tests/test_inifile.py
+++ b/tests/test_inifile.py
@@ -40,7 +40,7 @@ def test_misspelled_key():
     with pytest.raises(ConfigError) as e_info:
         read_pkg_ini(samples_dir / 'misspelled-key.ini')
 
-    assert 'scription-file' in str(e_info.value)
+    assert 'description-file' in str(e_info.value)
 
 def test_description_file():
     info = read_pkg_ini(samples_dir / 'package1-pkg.ini')


### PR DESCRIPTION
Error seem to be due to pytest wrapping errors, and the str()
representation of the error not always having the full error message of
the underlying error.