### PR TITLE
Add a "Why Flit?" section: Implements #273

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,10 @@
 **Flit** is a simple way to put Python packages and modules on PyPI.
 
+Why Flit
+-------
+* Flit enables you to publish your package to PyPI in a simple 3 step process ``flit init``, ``build`` & ``publish``.
+* Wheels built by flit are [reproducible](https://flit.readthedocs.io/en/latest/reproducible.html): if you build from the same source code, you should be able to make wheels that are exactly identical, byte for byte. This is useful for verifying software. For more details, see reproducible-builds.org.
+
 Install
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 Why Flit
 -------
 * Flit enables you to publish your package to PyPI in a simple 3 step process ``flit init``, ``build`` & ``publish``.
-* Wheels built by flit are [reproducible](https://flit.readthedocs.io/en/latest/reproducible.html): if you build from the same source code, you should be able to make wheels that are exactly identical, byte for byte. This is useful for verifying software. For more details, see reproducible-builds.org.
+* Wheels built by flit are `reproducible <https://flit.readthedocs.io/en/latest/reproducible.html/>`_ : if you build from the same source code, you should be able to make wheels that are exactly identical, byte for byte. This is useful for verifying software. For more details, see reproducible-builds.org.
 
 Install
 -------

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 Why Flit
 -------
-* Flit enables you to publish your package to PyPI in a simple 3 step process ``flit init``, ``build`` & ``publish``.
+* Flit enables you to publish your package to PyPI in a simple three step process ``flit init``, ``build`` & ``publish``.
 * Wheels built by flit are `reproducible <https://flit.readthedocs.io/en/latest/reproducible.html/>`_ : if you build from the same source code, you should be able to make wheels that are exactly identical, byte for byte. This is useful for verifying software. For more details, see reproducible-builds.org.
 
 Install


### PR DESCRIPTION
Adds a why Flit section to the project info documentation. Implements #273 

Quoting @guettli in #273 
```
I look at this page: https://flit.readthedocs.io/en/latest/index.html
I have never used flit before and I don't know why I should do it.
Please create a new section before "Install". Maybe with the title "why" or "Introduction".
Please tell us why you think flit should get used.
```