### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.8"
   - "3.7"
   - "3.6"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: python
 python:
+  - "3.7"
   - "3.6"
   - "3.5"
   - "3.4"
-
-# 3.7 needs Xenial image because of https://github.com/travis-ci/travis-ci/issues/9069
-matrix:
-  include:
-    - python: "3.7"
-      dist: xenial
 
 install:
   - pip install --upgrade pip

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36,py37
+envlist = py34,py35,py36,py37,py38
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Released yesterday: https://discuss.python.org/t/python-3-8-0-is-now-available/2478

We can also simplify the CI matrix a bit because Xenial is now default.
