### PR TITLE
make Author-email field optional

### DIFF
--- a/flit/common.py
+++ b/flit/common.py
@@ -234,7 +234,7 @@ class Metadata:
     def __init__(self, data):
         self.name = data.pop('name')
         self.version = data.pop('version')
-        self.author_email = data.pop('author_email')
+        self.author_email = data.pop('author_email', None)
         self.summary = data.pop('summary')
 
         for k, v in data.items():

--- a/flit/inifile.py
+++ b/flit/inifile.py
@@ -40,7 +40,6 @@ metadata_allowed_fields = {
 metadata_required_fields = {
     'module',
     'author',
-    'author-email',
 }
 
 

--- a/flit/init.py
+++ b/flit/init.py
@@ -65,7 +65,7 @@ class IniterBase:
 
     def validate_email(self, s):
         # Properly validating an email address is much more complex
-        return bool(re.match(r'.+@.+', s))
+        return bool(re.match(r'.+@.+', s)) or s == ""
 
     def validate_homepage(self, s):
         return not s or s.startswith(('http://', 'https://'))
@@ -179,8 +179,9 @@ class TerminalIniter(IniterBase):
         metadata = OrderedDict([
             ('module', module),
             ('author', author),
-            ('author-email', author_email),
         ])
+        if author_email:
+            metadata['author-email'] = author_email
         if home_page:
             metadata['home-page'] = home_page
         if license != 'skip':

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -148,3 +148,25 @@ def test_init_homepage_validator():
         'home-page': 'https://www.example.org',
         'module': 'test_module_name',
     }
+
+def test_author_email_field_is_optional():
+    responses = ['test_module_name',
+                 'Test Author',
+                 '',  # Author-email field is skipped
+                 'https://www.example.org',
+                 '4',
+                ]
+    with TemporaryDirectory() as td, \
+          patch_data_dir(), \
+          faking_input(responses):
+        ti = init.TerminalIniter(td)
+        ti.initialise()
+        with Path(td, 'pyproject.toml').open() as f:
+            data = pytoml.load(f)
+        assert not Path(td, 'LICENSE').exists()
+    metadata = data['tool']['flit']['metadata']
+    assert metadata == {
+        'author': 'Test Author',
+        'module': 'test_module_name',
+        'home-page': 'https://www.example.org',
+    }


### PR DESCRIPTION
The core metadata spec says it should be optional  https://packaging.python.org/specifications/core-metadata/#author-email

Related: https://github.com/takluyver/flit/issues/236

Anecdotally, I've seen people confused about what to do when they don't want a public email associated (currently they can only use flit by entering a fake email address there)