### PR TITLE
Development install for Flit itself

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,18 +73,3 @@ To install a package locally for development, run::
 Flit packages a single importable module or package at a time, using the import
 name as the name on PyPI. All subpackages and data files within a package are
 included automatically.
-
-Development
------------
-
-To install the development version of Flit from Github::
-
-    git clone https://github.com/takluyver/flit.git
-    cd flit
-    python3 -m pip install docutils requests pytoml
-    python3 -m flit install
-
-You may want to use the ``--symlink`` or ``--pth-file`` options so you can test
-changes without reinstalling it.
-
-To run the tests, run ``pytest``.

--- a/bootstrap_dev.py
+++ b/bootstrap_dev.py
@@ -30,14 +30,19 @@ core_config.module = 'flit_core'
 core_config.metadata = build_thyself.metadata_dict
 core_config.reqs_by_extra['.none'] = build_thyself.metadata.requires_dist
 
+install_kwargs = {'symlink': True}
+if os.name == 'nt':
+    # Use .pth files instead of symlinking on Windows
+    install_kwargs = {'symlink': False, 'pth': True}
+
 # Install flit_core
 Installer(
-    my_dir / 'flit_core', core_config, symlink=True, user=args.user,
+    my_dir / 'flit_core', core_config, user=args.user, **install_kwargs
 ).install()
 print("Linked flit_core into site-packages.")
 
 # Install flit
 Installer.from_ini_path(
-    my_dir / 'pyproject.toml', symlink=True, user=args.user,
+    my_dir / 'pyproject.toml', user=args.user, **install_kwargs
 ).install()
 print("Linked flit into site-packages.")

--- a/bootstrap_dev.py
+++ b/bootstrap_dev.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python3
+
+# Symlink install flit & flit_core for development.
+# Most projects can do the same with 'flit install --symlink'.
+# But that doesn't work until Flit is installed, so we need some bootstrapping.
+
 import argparse
 import logging
 import os

--- a/bootstrap_dev.py
+++ b/bootstrap_dev.py
@@ -1,0 +1,37 @@
+import argparse
+import logging
+import os
+from pathlib import Path
+import sys
+
+my_dir = Path(__file__).parent
+os.chdir(my_dir)
+sys.path.insert(0, 'flit_core')
+
+from flit_core import build_thyself
+from flit_core.inifile import LoadedConfig
+from flit.install import Installer
+
+ap = argparse.ArgumentParser()
+ap.add_argument('--user')
+args = ap.parse_args()
+
+logging.basicConfig(level=logging.INFO)
+
+# Construct config for flit_core
+core_config = LoadedConfig()
+core_config.module = 'flit_core'
+core_config.metadata = build_thyself.metadata_dict
+core_config.reqs_by_extra['.none'] = build_thyself.metadata.requires_dist
+
+# Install flit_core
+Installer(
+    my_dir / 'flit_core', core_config, symlink=True, user=args.user,
+).install()
+print("Linked flit_core into site-packages.")
+
+# Install flit
+Installer.from_ini_path(
+    my_dir / 'pyproject.toml', symlink=True, user=args.user,
+).install()
+print("Linked flit into site-packages.")

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -1,0 +1,26 @@
+Developing Flit
+===============
+
+To get a development installation of Flit itself::
+
+    git clone https://github.com/takluyver/flit.git
+    cd flit
+    python3 -m pip install docutils requests pytoml
+    python3 bootstrap_dev.py
+
+This links Flit into the current Python environment, so you can make changes
+and try them without having to reinstall each time.
+
+Testing
+-------
+
+To run the tests in separate environments for each available Python version::
+
+    tox
+
+`tox <https://tox.readthedocs.io/en/latest/>`_ has many options.
+
+To run the tests in your current environment, run::
+
+    pytest
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,6 +17,11 @@ Documentation contents
    cmdline
    upload
    reproducible
+
+.. toctree::
+   :maxdepth: 1
+
+   development
    history
 
 Indices and tables

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -150,7 +150,7 @@ def main(argv=None):
         from .install import Installer
         try:
             python = find_python_executable(args.python)
-            Installer(args.ini_file, user=args.user, python=python,
+            Installer.from_ini_path(args.ini_file, user=args.user, python=python,
                       symlink=args.symlink, deps=args.deps, extras=args.extras,
                       pth=args.pth_file).install()
         except (ConfigError, PythonNotFoundError, common.NoDocstringError, common.NoVersionError) as e:

--- a/flit_core/flit_core/build_thyself.py
+++ b/flit_core/flit_core/build_thyself.py
@@ -15,7 +15,7 @@ from .sdist import SdistBuilder
 
 from . import __version__
 
-metadata = Metadata({
+metadata_dict = {
     'name': 'flit_core',
     'version': __version__,
     'author': 'Thomas Kluyver & contributors',
@@ -31,7 +31,8 @@ metadata = Metadata({
         "License :: OSI Approved :: BSD License",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ]
-})
+}
+metadata = Metadata(metadata_dict)
 
 def get_requires_for_build_wheel(config_settings=None):
     """Returns a list of requirements for building, as strings"""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -28,12 +28,12 @@ class InstallTests(TestCase):
         self.get_dirs_patch.stop()
 
     def test_install_module(self):
-        Installer(samples_dir / 'module1' / 'flit.ini').install_directly()
+        Installer.from_ini_path(samples_dir / 'module1' / 'flit.ini').install_directly()
         assert_isfile(self.tmpdir / 'site-packages' / 'module1.py')
         assert_isdir(self.tmpdir / 'site-packages' / 'module1-0.1.dist-info')
 
     def test_install_package(self):
-        Installer(samples_dir / 'package1' / 'flit.ini').install_directly()
+        Installer.from_ini_path(samples_dir / 'package1' / 'flit.ini').install_directly()
         assert_isdir(self.tmpdir / 'site-packages' / 'package1')
         assert_isdir(self.tmpdir / 'site-packages' / 'package1-0.1.dist-info')
         assert_isfile(self.tmpdir / 'scripts' / 'pkg_script')
@@ -43,7 +43,7 @@ class InstallTests(TestCase):
     def test_symlink_package(self):
         if os.name == 'nt':
             raise SkipTest("symlink")
-        Installer(samples_dir / 'package1' / 'flit.ini', symlink=True).install()
+        Installer.from_ini_path(samples_dir / 'package1' / 'flit.ini', symlink=True).install()
         assert_islink(self.tmpdir / 'site-packages' / 'package1',
                       to=samples_dir / 'package1' / 'package1')
         assert_isfile(self.tmpdir / 'scripts' / 'pkg_script')
@@ -51,23 +51,23 @@ class InstallTests(TestCase):
             assert f.readline().strip() == "#!" + sys.executable
 
     def test_pth_package(self):
-        Installer(samples_dir / 'package1' / 'flit.ini', pth=True).install()
+        Installer.from_ini_path(samples_dir / 'package1' / 'flit.ini', pth=True).install()
         assert_isfile(self.tmpdir / 'site-packages' / 'package1.pth')
         with open(str(self.tmpdir / 'site-packages' / 'package1.pth')) as f:
             assert f.read() == str(samples_dir / 'package1')
         assert_isfile(self.tmpdir / 'scripts' / 'pkg_script')
 
     def test_dist_name(self):
-        Installer(samples_dir / 'altdistname' / 'flit.ini').install_directly()
+        Installer.from_ini_path(samples_dir / 'altdistname' / 'flit.ini').install_directly()
         assert_isdir(self.tmpdir / 'site-packages' / 'package1')
         assert_isdir(self.tmpdir / 'site-packages' / 'package_dist1-0.1.dist-info')
 
     def test_entry_points(self):
-        Installer(samples_dir / 'entrypoints_valid' / 'flit.ini').install_directly()
+        Installer.from_ini_path(samples_dir / 'entrypoints_valid' / 'flit.ini').install_directly()
         assert_isfile(self.tmpdir / 'site-packages' / 'package1-0.1.dist-info' / 'entry_points.txt')
 
     def test_pip_install(self):
-        ins = Installer(samples_dir / 'package1' / 'flit.ini', python='mock_python',
+        ins = Installer.from_ini_path(samples_dir / 'package1' / 'flit.ini', python='mock_python',
                         user=False)
 
         with MockCommand('mock_python') as mock_py:
@@ -103,7 +103,7 @@ class InstallTests(TestCase):
                            scripts=str(self.tmpdir / 'scripts2'))
 
         with MockCommand('mock_python', content=script1):
-            ins = Installer(samples_dir / 'package1' / 'flit.ini', python='mock_python',
+            ins = Installer.from_ini_path(samples_dir / 'package1' / 'flit.ini', python='mock_python',
                       symlink=True)
         with MockCommand('mock_python', content=script2):
             ins.install()
@@ -115,7 +115,7 @@ class InstallTests(TestCase):
             assert f.readline().strip() == "#!mock_python"
 
     def test_install_requires(self):
-        ins = Installer(samples_dir / 'requires-requests.toml',
+        ins = Installer.from_ini_path(samples_dir / 'requires-requests.toml',
                         user=False, python='mock_python')
 
         with MockCommand('mock_python') as mockpy:
@@ -126,7 +126,7 @@ class InstallTests(TestCase):
 
     def test_extras_error(self):
         with pytest.raises(DependencyError):
-            Installer(samples_dir / 'requires-requests.toml',
+            Installer.from_ini_path(samples_dir / 'requires-requests.toml',
                             user=False, deps='none', extras='dev')
 
 @pytest.mark.parametrize(('deps', 'extras', 'installed'), [
@@ -139,7 +139,7 @@ def test_install_requires_extra(deps, extras, installed):
     it = InstallTests()
     try:
         it.setUp()
-        ins = Installer(samples_dir / 'extras' / 'pyproject.toml', python='mock_python',
+        ins = Installer.from_ini_path(samples_dir / 'extras' / 'pyproject.toml', python='mock_python',
                         user=False, deps=deps, extras=extras)
 
         cmd = MockCommand('mock_python')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,37,36,35,34,27}
+envlist = py{38,37,36,35,34,27},bootstrap
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Fixes #291, cc @uranusjr 

This adds a `bootstrap_dev.py` script to make it easy to get a development install of Flit to experiment with.