### PR TITLE
Correctly set up package_dir for src/ prefix

### DIFF
--- a/flit/sdist.py
+++ b/flit/sdist.py
@@ -183,6 +183,11 @@ class SdistBuilder(SdistBuilderCore):
         else:
             extra.append("py_modules={!r},".format([self.module.name]))
 
+        if self.module.prefix:
+            package_dir = pformat({'': self.module.prefix})
+            before.append("package_dir = \\\n%s\n" % package_dir)
+            extra.append("package_dir=package_dir,")
+
         install_reqs, extra_reqs = convert_requires(self.reqs_by_extra)
         if install_reqs:
             before.append("install_requires = \\\n%s\n" % pformat(install_reqs))

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -28,18 +28,22 @@ class Module(object):
         if osp.isdir(pkg_dir):
             self.path = pkg_dir
             self.is_package = True
+            self.prefix = ''
             existing.add(pkg_dir)
         elif osp.isfile(py_file):
             self.path = py_file
             self.is_package = False
+            self.prefix = ''
             existing.add(py_file)
         elif osp.isdir(src_pkg_dir):
             self.path = src_pkg_dir
             self.is_package = True
+            self.prefix = 'src'
             existing.add(src_pkg_dir)
         elif osp.isfile(src_py_file):
             self.path = src_py_file
             self.is_package = False
+            self.prefix = 'src'
             existing.add(src_py_file)
         else:
             raise ValueError("No file/folder found for module {}".format(name))

--- a/tests/samples/packageinsrc/pyproject.toml
+++ b/tests/samples/packageinsrc/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["flit"]
+build-backend = "flit.buildapi"
+
+[tool.flit.metadata]
+module = "module1"
+author = "Sir Robin"
+author-email = "robin@camelot.uk"
+home-page = "http://github.com/sirrobin/module1"
+requires = []

--- a/tests/samples/packageinsrc/src/module1.py
+++ b/tests/samples/packageinsrc/src/module1.py
@@ -1,0 +1,3 @@
+"""Example module"""
+
+__version__ = '0.1'

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -101,3 +101,8 @@ def test_make_setup_py_reqs_extra_envmark():
     builder = sdist.SdistBuilder.from_ini_path(samples_dir / 'requires-extra-envmark' / 'pyproject.toml')
     ns = get_setup_assigns(builder.make_setup_py())
     assert ns['extras_require'] == {'test:python_version == "2.7"': ['pathlib2']}
+
+def test_make_setup_py_package_dir_src():
+    builder = sdist.SdistBuilder.from_ini_path(samples_dir / 'packageinsrc' / 'pyproject.toml')
+    ns = get_setup_assigns(builder.make_setup_py())
+    assert ns['package_dir'] == {'': 'src'}


### PR DESCRIPTION
This adds something like

```python
package_dir = \
{'': 'src'}

setup(...
      package_dir=package_dir,
)
```

to setup.py if the module is found inside a `src/` prefix.

Fix #302.

Syntax reference: https://docs.python.org/3.9/distutils/setupscript.html#listing-whole-packages