### PR TITLE
Allow underscore for Python 2 identifiers

### DIFF
--- a/flit_core/flit_core/inifile.py
+++ b/flit_core/flit_core/inifile.py
@@ -16,7 +16,7 @@ if sys.version_info[0] >= 3:
     text_types = (str,)
 else:
     def isidentifier(s):
-        return bool(re.match('[A-Za-z][A-Za-z0-9]*$', s))
+        return bool(re.match('[A-Za-z_][A-Za-z0-9_]*$', s))
 
     text_types = (str, unicode)
 


### PR DESCRIPTION
I have added the missing underscore character in the regular expressing for Python 2 `isidentifier()` check.