### PR TITLE
Make bootstrap_dev work on Python 3.5

### DIFF
--- a/bootstrap_dev.py
+++ b/bootstrap_dev.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import sys
 
 my_dir = Path(__file__).parent
-os.chdir(my_dir)
+os.chdir(str(my_dir))
 sys.path.insert(0, 'flit_core')
 
 from flit_core import build_thyself


### PR DESCRIPTION
Since Flit itself support down to 3.5, the bootstrap script probably needs to as well. Unfortunately pathlib support was spotty back then.