### PR TITLE
fix(windows): Use `@echo off` in batch scripts

### DIFF
--- a/flit/install.py
+++ b/flit/install.py
@@ -185,7 +185,7 @@ class Installer(object):
 
             if sys.platform == 'win32':
                 cmd_file = script_file.with_suffix('.cmd')
-                cmd = '"{python}" "%~dp0\\{script}" %*\r\n'.format(
+                cmd = '@echo off\r\n"{python}" "%~dp0\\{script}" %*\r\n'.format(
                             python=self.python, script=name)
                 log.debug("Writing script wrapper to %s", cmd_file)
                 with cmd_file.open('w') as f:


### PR DESCRIPTION
The batch `echo` mode is ON by default on Windows. As a result, running
a custom CLI keep printing out the script location and the command that
was run.

Here is a custom CLI tool called `git-conventional-commit`,

With echo OFF (expected behavior):
```bash
git-conventional-changelog . -o
-o requires argument
Usage:
    git-conventional-changelog REPO [--output=<str>][--show-scope][--fake][--verbose]
    git-conventional-changelog -h | --help
    git-conventional-changelog --version
```

With echo ON (noise added to the command output):
```bash
git-conventional-changelog . -o

"C:\Users\Stephen\venv_projects\mylibs\git_history\venv\Scripts\python.exe" "C:\Users\Stephen\venv_projects\mylibs\git_history\venv\Scripts\\git-conventional-changelog" . -o
-o requires argument
Usage:
    git-conventional-changelog REPO [--output=<str>][--show-scope][--fake][--verbose]
    git-conventional-changelog -h | --help
    git-conventional-changelog --version
```