### PR TITLE
Add an option to make sdists without setup.py

### DIFF
--- a/doc/cmdline.rst
+++ b/doc/cmdline.rst
@@ -39,6 +39,12 @@ Build a wheel and an sdist (tarball) from the package.
 
    Limit to building either ``wheel`` or ``sdist``.
 
+.. option:: --no-setup-py
+
+   Don't generate a setup.py file in the sdist.
+   An sdist built without this will only work with tools that support PEP 517,
+   but the wheel will still be usable by any compatible tool.
+
 .. _publish_cmd:
 
 ``flit publish``
@@ -53,6 +59,12 @@ or another repository.
 
    Limit to publishing either ``wheel`` or ``sdist``.
    You should normally publish the two formats together.
+
+.. option:: --no-setup-py
+
+   Don't generate a setup.py file in the sdist.
+   An sdist built without this will only work with tools that support PEP 517,
+   but the wheel will still be usable by any compatible tool.
 
 .. option:: --repository <repository>
 

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -65,6 +65,13 @@ def main(argv=None):
         help="Select a format to build. Options: 'wheel', 'sdist'"
     )
 
+    parser_build.add_argument('--no-setup-py', action='store_false', dest='setup_py',
+        help=("Don't generate a setup.py file in the sdist. "
+              "The sdist will only work with tools that support PEP 517, "
+              "but the wheel will still be usable by any compatible tool."
+             )
+    )
+
     # flit publish --------------------------------------------
     parser_publish = subparsers.add_parser('publish',
         help="Upload wheel and sdist",
@@ -72,6 +79,13 @@ def main(argv=None):
 
     parser_publish.add_argument('--format', action='append',
         help="Select a format to publish. Options: 'wheel', 'sdist'"
+    )
+
+    parser_publish.add_argument('--no-setup-py', action='store_false', dest='setup_py',
+        help=("Don't generate a setup.py file in the sdist. "
+              "The sdist will only work with tools that support PEP 517, "
+              "but the wheel will still be usable by any compatible tool."
+             )
     )
 
     parser_publish.add_argument('--repository',
@@ -139,12 +153,14 @@ def main(argv=None):
     if args.subcmd == 'build':
         from .build import main
         try:
-            main(args.ini_file, formats=set(args.format or []))
+            main(args.ini_file, formats=set(args.format or []),
+                 gen_setup_py=args.setup_py)
         except(common.NoDocstringError, common.VCSError, common.NoVersionError) as e:
             sys.exit(e.args[0])
     elif args.subcmd == 'publish':
         from .upload import main
-        main(args.ini_file, args.repository, formats=set(args.format or []))
+        main(args.ini_file, args.repository, formats=set(args.format or []),
+             gen_setup_py=args.setup_py)
 
     elif args.subcmd == 'install':
         from .install import Installer

--- a/flit/build.py
+++ b/flit/build.py
@@ -26,7 +26,7 @@ def unpacked_tarball(path):
         assert len(files) == 1, files
         yield os.path.join(tmpdir, files[0])
 
-def main(ini_file: Path, formats=None):
+def main(ini_file: Path, formats=None, gen_setup_py=True):
     """Build wheel and sdist"""
     if not formats:
         formats = ALL_FORMATS
@@ -41,7 +41,7 @@ def main(ini_file: Path, formats=None):
 
         if 'sdist' in formats:
             sb = SdistBuilder.from_ini_path(ini_file)
-            sdist_file = sb.build(ini_file.parent / 'dist')
+            sdist_file = sb.build(ini_file.parent / 'dist', gen_setup_py=gen_setup_py)
             sdist_info = SimpleNamespace(builder=sb, file=sdist_file)
             # When we're building both, build the wheel from the unpacked sdist.
             # This helps ensure that the sdist contains all the necessary files.

--- a/flit/sdist.py
+++ b/flit/sdist.py
@@ -215,5 +215,5 @@ class SdistBuilder(SdistBuilderCore):
             extra='\n      '.join(extra),
         ).encode('utf-8')
 
-    def build(self, target_dir):
-        return Path(super().build(str(target_dir)))
+    def build(self, target_dir, gen_setup_py=True):
+        return Path(super().build(str(target_dir), gen_setup_py=gen_setup_py))

--- a/flit/upload.py
+++ b/flit/upload.py
@@ -261,10 +261,10 @@ def do_upload(file:Path, metadata:Metadata, repo_name=None):
         log.info("Package is at %s/%s", repo['url'], metadata.name)
 
 
-def main(ini_path, repo_name, formats=None):
+def main(ini_path, repo_name, formats=None, gen_setup_py=True):
     """Build and upload wheel and sdist."""
     from . import build
-    built = build.main(ini_path, formats=formats)
+    built = build.main(ini_path, formats=formats, gen_setup_py=gen_setup_py)
 
     if built.wheel is not None:
         do_upload(built.wheel.file, built.wheel.builder.metadata, repo_name)

--- a/flit_core/flit_core/sdist.py
+++ b/flit_core/flit_core/sdist.py
@@ -164,7 +164,7 @@ class SdistBuilder:
     def dir_name(self):
         return '{}-{}'.format(self.metadata.name, self.metadata.version)
 
-    def build(self, target_dir):
+    def build(self, target_dir, gen_setup_py=True):
         if not osp.isdir(target_dir):
             os.makedirs(target_dir)
         target = osp.join(
@@ -191,7 +191,8 @@ class SdistBuilder:
                 else:
                     tf.addfile(ti)  # Symlinks & ?
 
-            self.add_setup_py(files_to_add, tf)
+            if gen_setup_py:
+                self.add_setup_py(files_to_add, tf)
 
             pkg_info = PKG_INFO.format(
                 name=self.metadata.name,

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -31,7 +31,7 @@ def test_make_sdist():
         sdist_file = td / 'package1-0.1.tar.gz'
         assert_isfile(sdist_file)
 
-        with tarfile.open(sdist_file) as tf:
+        with tarfile.open(str(sdist_file)) as tf:
             assert 'package1-0.1/setup.py' in tf.getnames()
 
 
@@ -46,7 +46,7 @@ def test_sdist_no_setup_py():
         sdist_file = td / 'package1-0.1.tar.gz'
         assert_isfile(sdist_file)
 
-        with tarfile.open(sdist_file) as tf:
+        with tarfile.open(str(sdist_file)) as tf:
             assert 'package1-0.1/setup.py' not in tf.getnames()
 
 


### PR DESCRIPTION
The setup.py is a compatibility measure until we can rely on PEP 517. This lets people who want to bring the future forwards start relying on PEP 517 now.

Closes gh-304