### PR TITLE
Replace 'pytoml' with 'toml'.

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -5,7 +5,7 @@ To get a development installation of Flit itself::
 
     git clone https://github.com/takluyver/flit.git
     cd flit
-    python3 -m pip install docutils requests pytoml
+    python3 -m pip install docutils requests toml
     python3 bootstrap_dev.py
 
 This links Flit into the current Python environment, so you can make changes

--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -121,7 +121,7 @@ Here's the full metadata section from flit itself:
         "requests",
         "docutils",
         "requests_download",
-        "pytoml",
+        "toml",
     ]
     requires-python="3"
     description-file="README.rst"

--- a/flit/init.py
+++ b/flit/init.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 import re
 import sys
-import pytoml as toml
+import toml
 
 def get_data_dir():
     """Get the directory path for flit user data files.

--- a/flit/tomlify.py
+++ b/flit/tomlify.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 import configparser
 import os
 from pathlib import Path
-import pytoml
+import toml
 
 from .inifile import metadata_list_fields
 from .init import TEMPLATE
@@ -40,11 +40,11 @@ def convert(path):
 
     written_entrypoints = False
     with Path('pyproject.toml').open('w', encoding='utf-8') as f:
-        f.write(TEMPLATE.format(metadata=pytoml.dumps(metadata)))
+        f.write(TEMPLATE.format(metadata=toml.dumps(metadata)))
 
         if scripts:
             f.write('\n[tool.flit.scripts]\n')
-            pytoml.dump(scripts, f)
+            toml.dump(scripts, f)
 
         for groupname, group in entrypoints.items():
             if not dict(group):
@@ -53,7 +53,7 @@ def convert(path):
             if '.' in groupname:
                 groupname = '"{}"'.format(groupname)
             f.write('\n[tool.flit.entrypoints.{}]\n'.format(groupname))
-            pytoml.dump(OrderedDict(group), f)
+            toml.dump(OrderedDict(group), f)
             written_entrypoints = True
 
     print("Written 'pyproject.toml'")

--- a/flit_core/flit_core/build_thyself.py
+++ b/flit_core/flit_core/build_thyself.py
@@ -24,7 +24,7 @@ metadata_dict = {
     'summary': ('Distribution-building parts of Flit. '
                     'See flit package for more information'),
     'requires_dist': [
-        'pytoml',
+        'toml',
     ],
     'requires_python': '>=2.7, !=3.0, !=3.1, !=3.2, != 3.3',
     'classifiers': [

--- a/flit_core/flit_core/inifile.py
+++ b/flit_core/flit_core/inifile.py
@@ -4,7 +4,7 @@ import io
 import logging
 import os
 import os.path as osp
-import pytoml as toml
+import toml
 import re
 import sys
 

--- a/flit_core/flit_core/sdist.py
+++ b/flit_core/flit_core/sdist.py
@@ -94,7 +94,7 @@ class SdistBuilder:
 
     @classmethod
     def from_ini_path(cls, ini_path):
-        # Local import so bootstrapping doesn't try to load pytoml
+        # Local import so bootstrapping doesn't try to load toml
         from . import inifile
         ini_info = inifile.read_flit_config(ini_path)
         srcdir = osp.dirname(ini_path)

--- a/flit_core/flit_core/wheel.py
+++ b/flit_core/flit_core/wheel.py
@@ -78,7 +78,7 @@ class WheelBuilder:
 
     @classmethod
     def from_ini_path(cls, ini_path, target_fp):
-        # Local import so bootstrapping doesn't try to load pytoml
+        # Local import so bootstrapping doesn't try to load toml
         from . import inifile
         directory = osp.dirname(ini_path)
         ini_info = inifile.read_flit_config(ini_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires=[
     "flit_core>=2.2.0",
     "requests",
     "docutils",
-    "pytoml",
+    "toml",
     "zipfile36; python_version in '3.3 3.4 3.5'",
 ]
 requires-python=">=3.5"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,7 +5,7 @@ from tempfile import TemporaryDirectory
 from testpath import assert_isfile
 from unittest.mock import patch
 
-import pytoml
+import toml
 
 from flit import init
 
@@ -106,7 +106,7 @@ def test_init():
         generated = Path(td) / 'pyproject.toml'
         assert_isfile(generated)
         with generated.open() as f:
-            data = pytoml.load(f)
+            data = toml.load(f)
         assert data['tool']['flit']['metadata'][
                    'author-email'] == "test@example.com"
         license = Path(td) / 'LICENSE'
@@ -130,7 +130,7 @@ def test_init_homepage_and_license_are_optional():
         ti = init.TerminalIniter(td)
         ti.initialise()
         with Path(td, 'pyproject.toml').open() as f:
-            data = pytoml.load(f)
+            data = toml.load(f)
         assert not Path(td, 'LICENSE').exists()
     metadata = data['tool']['flit']['metadata']
     assert metadata == {
@@ -153,7 +153,7 @@ def test_init_homepage_validator():
         ti = init.TerminalIniter(td)
         ti.initialise()
         with Path(td, 'pyproject.toml').open() as f:
-            data = pytoml.load(f)
+            data = toml.load(f)
     metadata = data['tool']['flit']['metadata']
     assert metadata == {
         'author': 'Test Author',
@@ -175,7 +175,7 @@ def test_author_email_field_is_optional():
         ti = init.TerminalIniter(td)
         ti.initialise()
         with Path(td, 'pyproject.toml').open() as f:
-            data = pytoml.load(f)
+            data = toml.load(f)
         assert not Path(td, 'LICENSE').exists()
     metadata = data['tool']['flit']['metadata']
     assert metadata == {

--- a/tests/test_tomlify.py
+++ b/tests/test_tomlify.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-import pytoml
+import toml
 from shutil import copy
 from testpath import assert_isfile
 
@@ -18,7 +18,7 @@ def test_tomlify(copy_sample, monkeypatch):
     assert_isfile(pyproject_toml)
 
     with pyproject_toml.open(encoding='utf-8') as f:
-        content = pytoml.load(f)
+        content = toml.load(f)
 
     assert 'build-system' in content
     assert 'tool' in content

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     testpath
     responses
     docutils
-    pytoml
+    toml
     pytest>=2.7.3
     pytest-cov
 


### PR DESCRIPTION
The pytoml package is deprecated, and doesn't support the most recent TOML standard (e.g. dotted keys).