### PR TITLE
docs: add pygments to prerequisites for dev

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -5,7 +5,7 @@ To get a development installation of Flit itself::
 
     git clone https://github.com/takluyver/flit.git
     cd flit
-    python3 -m pip install docutils requests pytoml
+    python3 -m pip install docutils requests pytoml pygments
     python3 bootstrap_dev.py
 
 This links Flit into the current Python environment, so you can make changes


### PR DESCRIPTION
To get flit installed for development, pygments is also required but missing in the documentation.