### PR TITLE
ensures cache dir does exist

### DIFF
--- a/flit/validate.py
+++ b/flit/validate.py
@@ -63,7 +63,7 @@ def _download_and_cache_classifiers():
     try:
         with (cache_dir / 'classifiers.lst').open('wb') as f:
             f.write(resp.content)
-    except PermissionError:
+    except (PermissionError, FileNotFoundError):
         # cache file could not be created
         pass
     except OSError as e:

--- a/flit/validate.py
+++ b/flit/validate.py
@@ -57,7 +57,7 @@ def _download_and_cache_classifiers():
         pass
     except OSError as e:
         # readonly mounted file raises OSError, only these should be captured
-        if not e.errno == errno.EROFS:
+        if e.errno != errno.EROFS:
             raise
 
     try:
@@ -68,7 +68,7 @@ def _download_and_cache_classifiers():
         pass
     except OSError as e:
         # readonly mounted file raises OSError, only these should be captured
-        if not e.errno == errno.EROFS:
+        if e.errno != errno.EROFS:
             raise
 
     valid_classifiers = set(l.strip() for l in resp.text.splitlines())

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -132,14 +132,14 @@ def test_read_classifiers_cached(monkeypatch):
     assert classifiers == {'A', 'B', 'C'}
 
 
-def test_download_and_chache_classifiers():
-    classifiers = fv._download_and_chache_classifiers()
+def test_download_and_cache_classifiers():
+    classifiers = fv._download_and_cache_classifiers()
 
     assert isinstance(classifiers, set)
     assert "Development Status :: 1 - Planning" in classifiers
 
 
-def test_download_and_chache_classifiers_with_unacessible_dir(monkeypatch):
+def test_download_and_cache_classifiers_with_unacessible_dir(monkeypatch):
     def mock_get_cache_dir():
 
         class MockChache:
@@ -158,7 +158,7 @@ def test_download_and_chache_classifiers_with_unacessible_dir(monkeypatch):
 
     monkeypatch.setattr(fv, "get_cache_dir", mock_get_cache_dir)
 
-    classifiers = fv._download_and_chache_classifiers()
+    classifiers = fv._download_and_cache_classifiers()
 
     assert isinstance(classifiers, set)
     assert "Development Status :: 1 - Planning" in classifiers

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -153,13 +153,13 @@ def test_download_and_cache_classifiers_with_unacessible_dir(monkeypatch, error)
         'https://pypi.org/pypi?%3Aaction=list_classifiers',
         body="A\nB\nC")
 
-    class MockChacheDir:
+    class MockCacheDir:
         def mkdir(self, parents):
             raise error
         def __truediv__(self, other):
             raise error
 
-    monkeypatch.setattr(fv, "get_cache_dir", MockChacheDir)
+    monkeypatch.setattr(fv, "get_cache_dir", MockCacheDir)
 
     classifiers = fv._download_and_cache_classifiers()
 
@@ -174,11 +174,11 @@ def test_download_and_cache_classifiers_not_catching_oserror_mkdir(monkeypatch):
         body="A\nB\nC")
 
     unused_error_nr = max(errno.errorcode) + 1
-    class MockChacheDir:
+    class MockCacheDir:
         def mkdir(self, parents):
             raise OSError(unused_error_nr, "")
 
-    monkeypatch.setattr(fv, "get_cache_dir", MockChacheDir)
+    monkeypatch.setattr(fv, "get_cache_dir", MockCacheDir)
 
     with pytest.raises(OSError):
         fv._download_and_cache_classifiers()
@@ -192,13 +192,13 @@ def test_download_and_cache_classifiers_not_catching_oserror_on_write(monkeypatc
         body="A\nB\nC")
 
     unused_error_nr = max(errno.errorcode) + 1
-    class MockChacheDir:
+    class MockCacheDir:
         def mkdir(self, parents):
             raise PermissionError # will be catched
         def __truediv__(self, other):
             raise OSError(unused_error_nr, "")
 
-    monkeypatch.setattr(fv, "get_cache_dir", MockChacheDir)
+    monkeypatch.setattr(fv, "get_cache_dir", MockCacheDir)
 
     with pytest.raises(OSError):
         fv._download_and_cache_classifiers()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -116,7 +116,7 @@ def test_read_classifiers_cached(monkeypatch, tmp_path):
 
     def mock_get_cache_dir():
         tmp_file = tmp_path / "classifiers.lst"
-        with open(tmp_file, "w") as fh:
+        with tmp_file.open("w") as fh:
             fh.write("A\nB\nC")
         return tmp_path
 
@@ -128,11 +128,16 @@ def test_read_classifiers_cached(monkeypatch, tmp_path):
 
 
 @responses.activate
-def test_download_and_cache_classifiers():
+def test_download_and_cache_classifiers(monkeypatch, tmp_file):
     responses.add(
         responses.GET,
         'https://pypi.org/pypi?%3Aaction=list_classifiers',
         body="A\nB\nC")
+
+    def mock_get_cache_dir():
+        return tmp_path
+
+    monkeypatch.setattr(fv, "get_cache_dir", mock_get_cache_dir)
 
     classifiers = fv._download_and_cache_classifiers()
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -131,13 +131,18 @@ def patch_for_get_cache_dir():
         fv.os.environ["XDG_CACHE_HOME"] = original_xdg
     fv.os.path.expanduser = original_expanduser
 
+
+# the following test will fail on windows, since windows allows the creation
+# of the directory "/dev/null/nonexistent/flit"
+
+@pytest.mark.skipif(os.name == 'nt', reason="Test will fail on windows")
 def test_get_cache_with_temporary_directory(patch_for_get_cache_dir):
     # clear the functools.lru_cache, might be prefilled from other tests
     fv.get_cache_dir.cache_clear()
 
     cache_dir = fv.get_cache_dir()
 
-    # only temporary cache directory will not end in "flit"
+    # a posix temporary cache directory will not end in "flit"
     assert cache_dir.name != "flit"
 
     # two calls to get_cache_dir() should return the same temporary directory

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -128,7 +128,7 @@ def test_read_classifiers_cached(monkeypatch, tmp_path):
 
 
 @responses.activate
-def test_download_and_cache_classifiers(monkeypatch, tmp_file):
+def test_download_and_cache_classifiers(monkeypatch, tmp_path):
     responses.add(
         responses.GET,
         'https://pypi.org/pypi?%3Aaction=list_classifiers',

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -166,44 +166,6 @@ def test_download_and_cache_classifiers_with_unacessible_dir(monkeypatch, error)
     assert classifiers == {"A", "B", "C"}
 
 
-@responses.activate
-def test_download_and_cache_classifiers_not_catching_oserror_mkdir(monkeypatch):
-    responses.add(
-        responses.GET,
-        'https://pypi.org/pypi?%3Aaction=list_classifiers',
-        body="A\nB\nC")
-
-    unused_error_nr = max(errno.errorcode) + 1
-    class MockCacheDir:
-        def mkdir(self, parents):
-            raise OSError(unused_error_nr, "")
-
-    monkeypatch.setattr(fv, "get_cache_dir", MockCacheDir)
-
-    with pytest.raises(OSError):
-        fv._download_and_cache_classifiers()
-
-
-@responses.activate
-def test_download_and_cache_classifiers_not_catching_oserror_on_write(monkeypatch):
-    responses.add(
-        responses.GET,
-        'https://pypi.org/pypi?%3Aaction=list_classifiers',
-        body="A\nB\nC")
-
-    unused_error_nr = max(errno.errorcode) + 1
-    class MockCacheDir:
-        def mkdir(self, parents):
-            raise PermissionError # will be catched
-        def __truediv__(self, other):
-            raise OSError(unused_error_nr, "")
-
-    monkeypatch.setattr(fv, "get_cache_dir", MockCacheDir)
-
-    with pytest.raises(OSError):
-        fv._download_and_cache_classifiers()
-
-
 def test_verify_classifiers_valid_classifiers():
     classifiers = {"A"}
     valid_classifiers = {"A", "B"}

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -114,28 +114,16 @@ def test_validate_project_urls():
 
 
 @pytest.fixture
-def patch_for_get_cache_dir():
+def patch_for_get_cache_dir(monkeypatch):
     # storing current environmental variables for resetting later
-    original_xdg = fv.os.environ.get("XDG_CACHE_HOME", None)
-    original_expanduser = fv.os.path.expanduser
-
-    # change the environmental variables for the test
-    fv.os.environ["XDG_CACHE_HOME"] = "/dev/null/nonexistent"
-    fv.os.path.expanduser = lambda x: "/dev/null/nonexistent"
-
-    # return controll to the test function
-    yield
-
-    # reset the previously stored variables
-    if original_xdg is not None:
-        fv.os.environ["XDG_CACHE_HOME"] = original_xdg
-    fv.os.path.expanduser = original_expanduser
+    monkeypatch.setenv("XDG_CACHE_HOME", "/dev/null/nonexistent")
+    monkeypatch.setattr(fv.os.path, "expanduser", lambda x: "/dev/null/nonexistent")
 
 
 # the following test will fail on windows, since windows allows the creation
 # of the directory "/dev/null/nonexistent/flit"
 
-@pytest.mark.skipif(os.name == 'nt', reason="Test will fail on windows")
+@pytest.mark.skipif(os.name == 'nt', reason="relies on typical unix paths")
 def test_get_cache_with_temporary_directory(patch_for_get_cache_dir):
     # clear the functools.lru_cache, might be prefilled from other tests
     fv.get_cache_dir.cache_clear()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -114,28 +114,24 @@ def test_validate_project_urls():
 
 
 @pytest.fixture
-def fixture_env_variable():
+def patch_for_get_cache_dir():
     # storing current environmental variables for resetting later
-    current_xdg = fv.os.environ.get("XDG_CACHE_HOME", None)
-    current_platform = fv.sys.platform
-    curernt_os_name = fv.os.name
+    original_xdg = fv.os.environ.get("XDG_CACHE_HOME", None)
+    original_expanduser = fv.os.path.expanduser
 
     # change the environmental variables for the test
     fv.os.environ["XDG_CACHE_HOME"] = "/dev/null/nonexistent"
-    fv.sys.platform = "linux"
-    fv.os.name = "posix"
+    fv.os.path.expanduser = lambda x: "/dev/null/nonexistent"
 
     # return controll to the test function
     yield
 
     # reset the previously stored variables
-    if current_xdg is not None:
-        fv.os.environ["XDG_CACHE_HOME"] = current_xdg
-    fv.sys.platform = current_platform
-    fv.os.name = curernt_os_name
+    if original_xdg is not None:
+        fv.os.environ["XDG_CACHE_HOME"] = original_xdg
+    fv.os.path.expanduser = original_expanduser
 
-
-def test_get_cache_with_temporary_directory(fixture_env_variable):
+def test_get_cache_with_temporary_directory(patch_for_get_cache_dir):
     # clear the functools.lru_cache, might be prefilled from other tests
     fv.get_cache_dir.cache_clear()
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -125,13 +125,9 @@ def patch_for_get_cache_dir(monkeypatch):
 
 @pytest.mark.skipif(os.name == 'nt', reason="relies on typical unix paths")
 def test_get_cache_with_temporary_directory(patch_for_get_cache_dir):
-    # clear the functools.lru_cache, might be prefilled from other tests
-    fv.get_cache_dir.cache_clear()
 
-    cache_dir = fv.get_cache_dir()
+    with fv.get_cache_dir() as cache_dir:
 
-    # a posix temporary cache directory will not end in "flit"
-    assert cache_dir.name != "flit"
+        # a posix temporary cache directory will not end in "flit"
+        assert cache_dir.name != "flit"
 
-    # two calls to get_cache_dir() should return the same temporary directory
-    assert cache_dir == fv.get_cache_dir()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -132,6 +132,7 @@ def test_read_classifiers_cached(monkeypatch):
     assert classifiers == {'A', 'B', 'C'}
 
 
+@pytest.mark.network
 def test_download_and_cache_classifiers():
     classifiers = fv._download_and_cache_classifiers()
 
@@ -139,6 +140,7 @@ def test_download_and_cache_classifiers():
     assert "Development Status :: 1 - Planning" in classifiers
 
 
+@pytest.mark.network
 def test_download_and_cache_classifiers_with_unacessible_dir(monkeypatch):
     def mock_get_cache_dir():
 


### PR DESCRIPTION
I ran into a problem when installing another project with flit for development purpose using `flit install --pth-file`.  The user had a non-existing home directory set (`/nonexistent') and therefore the download of the trove classifiers failed.

The `/nonexistent` "home" directory is used on POSIX systems to denote a user without a home directory, e.g. user `nobody` or users only set up for services.

These proposed changes ensures that a valid directory is returned by the `flit.validate.get_cache_dir()` function. 

If the `flit`-subdirectory of the cache-directory does not exist and could not be created, a temporary directory is used instead. To ensure that always the same temporary directory is used, the function is wrapped with the `functors.lru_cache()`.

A tests for this new behavior is also included. The tests passed so far on Mac OS X (Python 3.7 and 2.7) and on FreeBSD (Python 3.6)