### PR TITLE
Handle git submodules inclusion in sdist (fix #323)

### DIFF
--- a/flit/vcs/git.py
+++ b/flit/vcs/git.py
@@ -4,7 +4,8 @@ from subprocess import check_output
 name = 'git'
 
 def list_tracked_files(directory):
-    outb = check_output(['git', 'ls-files'], cwd=str(directory))
+    outb = check_output(['git', 'ls-files', '--recurse-submodules'],
+                        cwd=str(directory))
     return [os.fsdecode(l) for l in outb.strip().splitlines()]
 
 def list_untracked_deleted_files(directory):


### PR DESCRIPTION
With this change, the git submodules:
* Get included recursively instead of an empty directory
* Is correctly excluded from source distribution when `exclude` option is used for sdist

I would love to implement tests for this, however I cannot find the appropriate placement for it.