### PR TITLE
Declare projects compliant with flit_core 3.x by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ or as a directory — and you want to distribute it.
    .. code-block:: ini
 
        [build-system]
-       requires = ["flit_core >=2,<3"]
+       requires = ["flit_core >=2,<4"]
        build-backend = "flit_core.buildapi"
 
        [tool.flit.metadata]

--- a/doc/history.rst
+++ b/doc/history.rst
@@ -45,7 +45,7 @@ to look like this:
 .. code-block:: toml
 
     [build-system]
-    requires = ["flit_core >=2,<3"]
+    requires = ["flit_core >=2,<4"]
     build-backend = "flit_core.buildapi"
 
 Other changes include:

--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -21,7 +21,7 @@ defined by PEP 517. For any project using Flit, it will look like this:
 .. code-block:: toml
 
     [build-system]
-    requires = ["flit_core >=2,<3"]
+    requires = ["flit_core >=2,<4"]
     build-backend = "flit_core.buildapi"
 
 Metadata section

--- a/flit/init.py
+++ b/flit/init.py
@@ -210,7 +210,7 @@ class TerminalIniter(IniterBase):
 
 TEMPLATE = """\
 [build-system]
-requires = ["flit_core >=2,<3"]
+requires = ["flit_core >=2,<4"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=2.2.0,<3"]
+requires = ["flit_core >=2.2.0,<4"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]


### PR DESCRIPTION
All projects with metadata in pyproject.toml (not flit.ini) should continue to work with flit_core 3.x. I'm also planning to drop support for Python 2 again, but that will be handled automatically with the Requires-Python metadata field.