### PR TITLE
Fix find_python_executable error

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -6,6 +6,7 @@ import pathlib
 import shutil
 import subprocess
 import sys
+from typing import Optional, Sequence
 
 from flit_core import common
 from .inifile import ConfigError
@@ -18,7 +19,9 @@ log = logging.getLogger(__name__)
 
 class PythonNotFoundError(Exception): pass
 
-def find_python_executable(python):
+
+def find_python_executable(python: Optional[str] = None) -> str:
+    """Returns an absolute filepath to the executable of Python to use."""
     if not python:
         python = os.environ.get("FLIT_INSTALL_PYTHON")
     if not python:
@@ -34,7 +37,7 @@ def find_python_executable(python):
     ).strip()
 
 
-def add_shared_install_options(parser):
+def add_shared_install_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--user', action='store_true', default=None,
         help="Do a user-local install (default if site.ENABLE_USER_SITE is True)"
     )
@@ -45,7 +48,8 @@ def add_shared_install_options(parser):
         help="Target Python executable, if different from the one running flit"
     )
 
-def main(argv=None):
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument('-f', '--ini-file', type=pathlib.Path, default='pyproject.toml')
     ap.add_argument('-V', '--version', action='version', version='Flit '+__version__)

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -43,7 +43,7 @@ def find_python_executable(python: Optional[str] = None) -> str:
         ) from e
 
 
-def add_shared_install_options(parser: argparse.ArgumentParser) -> None:
+def add_shared_install_options(parser: argparse.ArgumentParser):
     parser.add_argument('--user', action='store_true', default=None,
         help="Do a user-local install (default if site.ENABLE_USER_SITE is True)"
     )
@@ -55,7 +55,7 @@ def add_shared_install_options(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def main(argv: Optional[Sequence[str]] = None) -> None:
+def main(argv=None):
     ap = argparse.ArgumentParser()
     ap.add_argument('-f', '--ini-file', type=pathlib.Path, default='pyproject.toml')
     ap.add_argument('-V', '--version', action='version', version='Flit '+__version__)

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -5,7 +5,7 @@ import os
 import pathlib
 import subprocess
 import sys
-from typing import Optional, Sequence
+from typing import Optional
 
 from flit_core import common
 from .inifile import ConfigError

--- a/tests/test_find_python_executable.py
+++ b/tests/test_find_python_executable.py
@@ -1,7 +1,10 @@
 import os
+import re
 import sys
 
-from flit import find_python_executable
+import pytest
+
+from flit import PythonNotFoundError, find_python_executable
 
 
 def test_default():
@@ -18,3 +21,10 @@ def test_abs():
 
 def test_find_in_path():
     assert os.path.isabs(find_python_executable("python"))
+
+
+@pytest.mark.parametrize("bad_python_name", ["pyhton", "ls", "."])
+def test_exception(bad_python_name: str):
+    """Test that an appropriate exception (that contains the error string) is raised."""
+    with pytest.raises(PythonNotFoundError, match=re.escape(bad_python_name)):
+        find_python_executable(bad_python_name)


### PR DESCRIPTION
Fixes #330 

I also took the liberty of adding type hints.

Behaviour before:
```bash
$ flit install --python pyhton
Python executable None not found
$ flit install --python ls
ls: cannot access 'import sys; print(sys.executable)': No such file or directory
Traceback (most recent call last):
  File "/PATH/bin/flit", line 8, in <module>
    sys.exit(main())
  File "/PATH/lib/python3.7/site-packages/flit/__init__.py", line 168, in main
    python = find_python_executable(args.python)
  File "/PATH/lib/python3.7/site-packages/flit/__init__.py", line 33, in find_python_executable
    universal_newlines=True,
  File "/PATH/lib/python3.7/subprocess.py", line 411, in check_output
    **kwargs).stdout
  File "/PATH/lib/python3.7/subprocess.py", line 512, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/PATH/ls', '-c', 'import sys; print(sys.executable)']' returned non-zero exit status 2.
$ flit install --python .
Python executable None not found
```

Behaviour after:
```bash
$ flit install --python pyhton
Python executable 'pyhton' not found
$ flit install --python ls
ls: cannot access 'import sys; print(sys.executable)': No such file or directory
CalledProcessError occurred trying to find the absolute filepath of Python executable 'ls'
$ flit install --python .
PermissionError occurred trying to find the absolute filepath of Python executable '.'
```