### PR TITLE
PEP 610 (direct_url.json) support

### DIFF
--- a/flit/install.py
+++ b/flit/install.py
@@ -4,6 +4,7 @@ import logging
 import os
 import os.path as osp
 import csv
+import json
 import pathlib
 import random
 import shutil
@@ -384,6 +385,16 @@ class Installer(object):
             with (dist_info / 'entry_points.txt').open('w') as f:
                 common.write_entry_points(self.ini_info.entrypoints, f)
             self.installed_files.append(dist_info / 'entry_points.txt')
+
+        with (dist_info / 'direct_url.json').open('w', encoding='utf-8') as f:
+            json.dump(
+                {
+                    "url": self.directory.as_uri(),
+                    "dir_info": {"editable": bool(self.symlink or self.pth)}
+                },
+                f
+            )
+        self.installed_files.append(dist_info / 'direct_url.json')
 
         with (dist_info / 'RECORD').open('w', encoding='utf-8') as f:
             cf = csv.writer(f)

--- a/flit/install.py
+++ b/flit/install.py
@@ -329,34 +329,26 @@ class Installer(object):
         self.write_dist_info(dirs['purelib'])
 
     def install_with_pip(self):
+        """Let pip install the project directory
+
+        pip will create an isolated build environment and install build
+        dependencies, which means downloading flit_core from PyPI. We ask pip
+        to install the project directory (instead of building a temporary wheel
+        and asking pip to install it), so pip will record the project directory
+        in direct_url.json.
+        """
         self.install_reqs_my_python_if_needed()
-
-        with tempfile.TemporaryDirectory() as td:
-            temp_whl = osp.join(td, 'temp.whl')
-            with open(temp_whl, 'w+b') as fp:
-                wb = WheelBuilder(
-                    str(self.directory),
-                    self.module,
-                    metadata=common.make_metadata(self.module, self.ini_info),
-                    entrypoints=self.ini_info.entrypoints,
-                    target_fp=fp,
-                )
-                wb.build()
-
-            renamed_whl = osp.join(td, wb.wheel_filename)
-            os.rename(temp_whl, renamed_whl)
-            extras = self._extras_to_install()
-            extras.discard('.none')
-            whl_with_extras = '{}[{}]'.format(renamed_whl, ','.join(extras)) \
-                if extras else renamed_whl
-
-            cmd = [self.python, '-m', 'pip', 'install', whl_with_extras]
-            if self.user:
-                cmd.append('--user')
-            if self.deps == 'none':
-                cmd.append('--no-deps')
-            shell = (os.name == 'nt')
-            check_call(cmd, shell=shell)
+        extras = self._extras_to_install()
+        extras.discard('.none')
+        req_with_extras = '{}[{}]'.format(self.directory, ','.join(extras)) \
+            if extras else str(self.directory)
+        cmd = [self.python, '-m', 'pip', 'install', req_with_extras]
+        if self.user:
+            cmd.append('--user')
+        if self.deps == 'none':
+            cmd.append('--no-deps')
+        shell = (os.name == 'nt')
+        check_call(cmd, shell=shell)
 
     def write_dist_info(self, site_pkgs):
         """Write dist-info folder, according to PEP 376"""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -77,7 +77,7 @@ class InstallTests(TestCase):
         assert len(calls) == 1
         cmd = calls[0]['argv']
         assert cmd[1:4] == ['-m', 'pip', 'install']
-        assert cmd[4].endswith('package1-0.1-py2.py3-none-any.whl')
+        assert cmd[4].endswith('package1')
 
     def test_symlink_other_python(self):
         if os.name == 'nt':

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pathlib
 import sys
@@ -27,10 +28,27 @@ class InstallTests(TestCase):
     def tearDown(self):
         self.get_dirs_patch.stop()
 
+    def _assert_direct_url(self, directory, package, version, expected_editable):
+        direct_url_file = (
+            self.tmpdir
+            / 'site-packages'
+            / '{}-{}.dist-info'.format(package, version)
+            / 'direct_url.json'
+        )
+        assert_isfile(direct_url_file)
+        with direct_url_file.open() as f:
+            direct_url = json.load(f)
+            assert direct_url['url'].startswith('file:///')
+            assert direct_url['url'] == directory.as_uri()
+            assert direct_url['dir_info'].get('editable') is expected_editable
+
     def test_install_module(self):
         Installer.from_ini_path(samples_dir / 'module1_ini' / 'flit.ini').install_directly()
         assert_isfile(self.tmpdir / 'site-packages' / 'module1.py')
         assert_isdir(self.tmpdir / 'site-packages' / 'module1-0.1.dist-info')
+        self._assert_direct_url(
+            samples_dir / 'module1_ini', 'module1', '0.1', expected_editable=False
+        )
 
     def test_install_package(self):
         Installer.from_ini_path(samples_dir / 'package1' / 'flit.ini').install_directly()
@@ -39,6 +57,9 @@ class InstallTests(TestCase):
         assert_isfile(self.tmpdir / 'scripts' / 'pkg_script')
         with (self.tmpdir / 'scripts' / 'pkg_script').open() as f:
             assert f.readline().strip() == "#!" + sys.executable
+        self._assert_direct_url(
+            samples_dir / 'package1', 'package1', '0.1', expected_editable=False
+        )
 
     def test_symlink_package(self):
         if os.name == 'nt':
@@ -49,6 +70,9 @@ class InstallTests(TestCase):
         assert_isfile(self.tmpdir / 'scripts' / 'pkg_script')
         with (self.tmpdir / 'scripts' / 'pkg_script').open() as f:
             assert f.readline().strip() == "#!" + sys.executable
+        self._assert_direct_url(
+            samples_dir / 'package1', 'package1', '0.1', expected_editable=True
+        )
 
     def test_pth_package(self):
         Installer.from_ini_path(samples_dir / 'package1' / 'flit.ini', pth=True).install()
@@ -56,6 +80,9 @@ class InstallTests(TestCase):
         with open(str(self.tmpdir / 'site-packages' / 'package1.pth')) as f:
             assert f.read() == str(samples_dir / 'package1')
         assert_isfile(self.tmpdir / 'scripts' / 'pkg_script')
+        self._assert_direct_url(
+            samples_dir / 'package1', 'package1', '0.1', expected_editable=True
+        )
 
     def test_dist_name(self):
         Installer.from_ini_path(samples_dir / 'altdistname' / 'flit.ini').install_directly()


### PR DESCRIPTION
Initial PEP 610 support is merged in pip master (will be in pip 20.1). This PR is meant to add PEP 610 support to flit.

- [x] support for `flit install --symlink/--pth-file`
- [x] suport for `flit install`
- [x] tests

Currently `flit install` (without --symlink/--pth-file) builds a wheel then invokes `pip install {temporary wheel file}`. This means pip will consider the wheel is being installed from a direct url which is actually a temporary file and will record that temporary url. The desired behaviour is to record the url of the local project directory.

To achieve that desired behaviour, there are two options:

1. Change `install_with_pip()` to merely do `pip install {self.directory}` and let pip do the PEP 517 build and install. That is the simplest approach, but has the drawback of possibly invoking another version of `flit` as build backend, and being somewhat slower. 
2. Keep `install_with_pip()` as is and patch the generated `direct_url.json` to point to the local project directory. This is somewhat complex because the `direct_url.json` that has been generated by pip has to be found correctly, and its hash in the `RECORD` file has to be updated.
