### PR TITLE
When doing `flit init`, if readme file is available, add it to pyproject.toml

### DIFF
--- a/flit/init.py
+++ b/flit/init.py
@@ -126,6 +126,13 @@ class IniterBase:
         with (self.directory / 'LICENSE').open('w', encoding='utf-8') as f:
             f.write(license_text.format(year=year, author=author))
 
+    def find_readme(self):
+        allowed = ("readme.md","readme.rst","readme.txt")
+        for fl in self.directory.glob("*.*"):
+            if fl.name.lower() in allowed:
+                return fl.name
+        return None
+
 
 class TerminalIniter(IniterBase):
     def prompt_text(self, prompt, default, validator, retry_msg="Try again."):
@@ -187,6 +194,13 @@ class TerminalIniter(IniterBase):
         license = self.prompt_options('Choose a license (see http://choosealicense.com/ for more info)',
                     license_choices, self.defaults.get('license'))
 
+        readme = self.find_readme()
+        if readme:
+            resp = input(f"Readme file found in the root of the project ({readme}) \n"
+                         "- Use this for the 'description-file'? [y/N]: ")
+            if (not resp) or resp[0].lower() != 'y':
+                readme = None
+
         self.update_defaults(author=author, author_email=author_email,
                              home_page=home_page, module=module, license=license)
 
@@ -201,6 +215,8 @@ class TerminalIniter(IniterBase):
         if license != 'skip':
             metadata['classifiers'] = [license_names_to_classifiers[license]]
             self.write_license(license, author)
+        if readme:
+            metadata['description-file'] = readme
 
         with (self.directory / 'pyproject.toml').open('w', encoding='utf-8') as f:
             f.write(TEMPLATE.format(metadata=toml.dumps(metadata)))

--- a/flit/init.py
+++ b/flit/init.py
@@ -196,8 +196,8 @@ class TerminalIniter(IniterBase):
 
         readme = self.find_readme()
         if readme:
-            resp = input(f"Readme file found in the root of the project ({readme}) \n"
-                         "- Use this for the 'description-file'? [y/N]: ")
+            resp = input("Readme found in the project root ({}) - Use this for the 'description-file'? [y/N]: ".format(readme))
+
             if (not resp) or resp[0].lower() != 'y':
                 readme = None
 

--- a/flit/init.py
+++ b/flit/init.py
@@ -195,11 +195,6 @@ class TerminalIniter(IniterBase):
                     license_choices, self.defaults.get('license'))
 
         readme = self.find_readme()
-        if readme:
-            resp = input("Readme found in the project root ({}) - Use this for the 'description-file'? [y/N]: ".format(readme))
-
-            if (not resp) or resp[0].lower() != 'y':
-                readme = None
 
         self.update_defaults(author=author, author_email=author_email,
                              home_page=home_page, module=module, license=license)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from testpath import assert_isfile
 from unittest.mock import patch
+import pytest
 
 import pytoml
 
@@ -183,3 +184,70 @@ def test_author_email_field_is_optional():
         'module': 'test_module_name',
         'home-page': 'https://www.example.org',
     }
+
+
+@pytest.mark.parametrize(
+    "readme_file",
+    ["readme.md", "README.MD", "README.md",
+     "Readme.md", "readme.MD", "readme.rst",
+     "readme.txt"])
+def test_find_readme(readme_file):
+    with make_dir([readme_file]) as td:
+        ib = init.IniterBase(td)
+        assert ib.find_readme() == readme_file
+
+
+def test_find_readme_not_found():
+    with make_dir() as td:
+        ib = init.IniterBase(td)
+        assert ib.find_readme() is None
+
+@pytest.mark.parametrize("yes",["y","Y","yes"])
+def test_init_readme_found_yes_choosen(yes):
+    responses = ['test_module_name',
+                 'Test Author',
+                 'test_email@example.com',
+                 '',   # Home page omitted
+                 '4',  # Skip - choose a license later
+                 yes,  # Readme found and yes to include
+                ]
+    with make_dir(["readme.md"]) as td, \
+          patch_data_dir(), \
+          faking_input(responses):
+        ti = init.TerminalIniter(td)
+        ti.initialise()
+        with Path(td, 'pyproject.toml').open() as f:
+            data = pytoml.load(f)
+
+    metadata = data['tool']['flit']['metadata']
+    assert metadata == {
+        'author': 'Test Author',
+        'author-email': 'test_email@example.com',
+        'module': 'test_module_name',
+        'description-file': 'readme.md'
+    }
+
+@pytest.mark.parametrize("no",["","N","n"])
+def test_init_readme_found_no_choosen(no):
+    responses = ['test_module_name',
+                 'Test Author',
+                 'test_email@example.com',
+                 '',  # Home page omitted
+                 '4',  # Skip - choose a license later
+                 no,  # Readme found and yes to include
+                 ]
+    with make_dir(["readme.md"]) as td, \
+            patch_data_dir(), \
+            faking_input(responses):
+        ti = init.TerminalIniter(td)
+        ti.initialise()
+        with Path(td, 'pyproject.toml').open() as f:
+            data = pytoml.load(f)
+
+    metadata = data['tool']['flit']['metadata']
+    assert metadata == {
+        'author': 'Test Author',
+        'author-email': 'test_email@example.com',
+        'module': 'test_module_name',
+    }
+

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -202,14 +202,13 @@ def test_find_readme_not_found():
         ib = init.IniterBase(td)
         assert ib.find_readme() is None
 
-@pytest.mark.parametrize("yes",["y","Y","yes"])
-def test_init_readme_found_yes_choosen(yes):
+
+def test_init_readme_found_yes_choosen():
     responses = ['test_module_name',
                  'Test Author',
                  'test_email@example.com',
                  '',   # Home page omitted
                  '4',  # Skip - choose a license later
-                 yes,  # Readme found and yes to include
                 ]
     with make_dir(["readme.md"]) as td, \
           patch_data_dir(), \
@@ -226,28 +225,3 @@ def test_init_readme_found_yes_choosen(yes):
         'module': 'test_module_name',
         'description-file': 'readme.md'
     }
-
-@pytest.mark.parametrize("no",["","N","n"])
-def test_init_readme_found_no_choosen(no):
-    responses = ['test_module_name',
-                 'Test Author',
-                 'test_email@example.com',
-                 '',  # Home page omitted
-                 '4',  # Skip - choose a license later
-                 no,  # Readme found and yes to include
-                 ]
-    with make_dir(["readme.md"]) as td, \
-            patch_data_dir(), \
-            faking_input(responses):
-        ti = init.TerminalIniter(td)
-        ti.initialise()
-        with Path(td, 'pyproject.toml').open() as f:
-            data = pytoml.load(f)
-
-    metadata = data['tool']['flit']['metadata']
-    assert metadata == {
-        'author': 'Test Author',
-        'author-email': 'test_email@example.com',
-        'module': 'test_module_name',
-    }
-


### PR DESCRIPTION
When doing `flit init`, flit will look for a readme file in the root of the project. (`readme.md`, `readme.rst`, `readme.txt`, lower or uppercase). If found it will ask the user to include it in the `pyproject.toml` file as an `description-file` entry.