### PR TITLE
Re-drop Python 2 support in flit_core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.6"
   - "3.5"
   - "3.4"  # 3.4 & 2.7 only test flit_core - see tox.ini
-  - "2.7"
 
 jobs:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@ environment:
       TOX_APPVEYOR_X64: "1"
     - TOXENV: "py35"
       TOX_APPVEYOR_X64: "0"
-    - TOXENV: "py27"
-      TOX_APPVEYOR_X64: "1"
 
 # The Python version here doesn't matter (except that the commands have the same),
 # as Tox will set up an environment using the Python specified above.

--- a/flit/config.py
+++ b/flit/config.py
@@ -8,7 +8,7 @@ from .validate import validate_config
 def read_flit_config(path):
     """Read and check the `pyproject.toml` or `flit.ini` file with data about the package.
     """
-    res = _read_flit_config_core(str(path))
+    res = _read_flit_config_core(path)
 
     if validate_config(res):
         if os.environ.get('FLIT_ALLOW_INVALID'):

--- a/flit/install.py
+++ b/flit/install.py
@@ -285,7 +285,7 @@ class Installer(object):
         os.makedirs(dirs['purelib'], exist_ok=True)
         os.makedirs(dirs['scripts'], exist_ok=True)
 
-        dst = osp.join(dirs['purelib'], osp.basename(self.module.path))
+        dst = osp.join(dirs['purelib'], self.module.path.name)
         if osp.lexists(dst):
             if osp.isdir(dst) and not osp.islink(dst):
                 shutil.rmtree(dst)
@@ -303,12 +303,12 @@ class Installer(object):
         src = str(self.module.path)
         if self.symlink:
             log.info("Symlinking %s -> %s", src, dst)
-            os.symlink(osp.abspath(self.module.path), dst)
+            os.symlink(osp.abspath(src), dst)
             self.installed_files.append(dst)
         elif self.pth:
             # .pth points to the the folder containing the module (which is
             # added to sys.path)
-            pth_target = osp.dirname(osp.abspath(self.module.path))
+            pth_target = osp.dirname(osp.abspath(src))
             pth_file = pathlib.Path(dst).with_suffix('.pth')
             log.info("Adding .pth file %s for %s", pth_file, pth_target)
             with pth_file.open("w") as f:

--- a/flit/install.py
+++ b/flit/install.py
@@ -105,7 +105,7 @@ class Installer(object):
         if deps == 'none' and extras:
             raise DependencyError()
 
-        self.module = common.Module(self.ini_info.module, str(directory))
+        self.module = common.Module(self.ini_info.module, directory)
 
         if (hasattr(os, 'getuid') and (os.getuid() == 0) and
                 (not os.environ.get('FLIT_ROOT_INSTALL'))):

--- a/flit/sdist.py
+++ b/flit/sdist.py
@@ -140,10 +140,6 @@ class SdistBuilder(SdistBuilderCore):
     - Add a generated setup.py for compatibility with tools which don't yet know
       about PEP 517.
     """
-    @classmethod
-    def from_ini_path(cls, ini_path: Path):
-        return super().from_ini_path(str(ini_path))
-
     def select_files(self):
         cfgdir_path = Path(self.cfgdir)
         vcs_mod = identify_vcs(cfgdir_path)
@@ -219,5 +215,3 @@ class SdistBuilder(SdistBuilderCore):
             extra='\n      '.join(extra),
         ).encode('utf-8')
 
-    def build(self, target_dir, gen_setup_py=True):
-        return Path(super().build(str(target_dir), gen_setup_py=gen_setup_py))

--- a/flit/sdist.py
+++ b/flit/sdist.py
@@ -141,10 +141,9 @@ class SdistBuilder(SdistBuilderCore):
       about PEP 517.
     """
     def select_files(self):
-        cfgdir_path = Path(self.cfgdir)
-        vcs_mod = identify_vcs(cfgdir_path)
+        vcs_mod = identify_vcs(self.cfgdir)
         if vcs_mod is not None:
-            untracked_deleted = vcs_mod.list_untracked_deleted_files(cfgdir_path)
+            untracked_deleted = vcs_mod.list_untracked_deleted_files(self.cfgdir)
             if any(include_path(p) and not self.excludes.match_file(p)
                    for p in untracked_deleted):
                 raise VCSError(
@@ -153,7 +152,7 @@ class SdistBuilder(SdistBuilderCore):
                     self.cfgdir)
 
             files = [os.path.normpath(p)
-                     for p in vcs_mod.list_tracked_files(cfgdir_path)]
+                     for p in vcs_mod.list_tracked_files(self.cfgdir)]
             files = sorted(filter(include_path, files))
             log.info("Found %d files tracked in %s", len(files), vcs_mod.name)
         else:

--- a/flit/wheel.py
+++ b/flit/wheel.py
@@ -1,18 +1,12 @@
 import logging
-from pathlib import Path
 
 import flit_core.wheel as core_wheel
 
 log = logging.getLogger(__name__)
 
 def make_wheel_in(ini_path, wheel_directory):
-    info = core_wheel.make_wheel_in(str(ini_path), str(wheel_directory))
-    info.file = Path(info.file)
-    return info
-
+    return core_wheel.make_wheel_in(ini_path, wheel_directory)
 
 class WheelBuilder(core_wheel.WheelBuilder):
-    @classmethod
-    def from_ini_path(cls, ini_path, target_fp):
-        return super().from_ini_path(str(ini_path), target_fp)
+    pass
 

--- a/flit_core/flit_core/build_thyself.py
+++ b/flit_core/flit_core/build_thyself.py
@@ -7,10 +7,11 @@ Building any other packages occurs through flit_core.buildapi
 import io
 import os
 import os.path as osp
+from pathlib import Path
 import tempfile
 
 from .common import Metadata, Module, dist_info_name
-from .wheel import WheelBuilder, _write_wheel_file, _replace
+from .wheel import WheelBuilder, _write_wheel_file
 from .sdist import SdistBuilder
 
 from . import __version__
@@ -26,7 +27,7 @@ metadata_dict = {
     'requires_dist': [
         'pytoml',
     ],
-    'requires_python': '>=2.7, !=3.0, !=3.1, !=3.2, != 3.3',
+    'requires_python': '>=3.4',
     'classifiers': [
         "License :: OSI Approved :: BSD License",
         "Topic :: Software Development :: Libraries :: Python Modules",
@@ -58,8 +59,8 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     """Builds a wheel, places it in wheel_directory"""
-    srcdir = os.getcwd()
-    module = Module('flit_core', srcdir)
+    cwd = Path.cwd()
+    module = Module('flit_core', cwd)
 
     # We don't know the final filename until metadata is loaded, so write to
     # a temporary_file, and rename it afterwards.
@@ -67,7 +68,7 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     try:
         with io.open(fd, 'w+b') as fp:
             wb = WheelBuilder(
-                srcdir, module, metadata, entrypoints={}, target_fp=fp
+                cwd, module, metadata, entrypoints={}, target_fp=fp
             )
             wb.build()
 
@@ -81,14 +82,14 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
 
 def build_sdist(sdist_directory, config_settings=None):
     """Builds an sdist, places it in sdist_directory"""
-    srcdir = os.getcwd()
-    module = Module('flit_core', srcdir)
+    cwd = Path.cwd()
+    module = Module('flit_core', cwd)
     reqs_by_extra = {'.none': metadata.requires}
 
     sb = SdistBuilder(
-        module, metadata, srcdir, reqs_by_extra, entrypoints={},
+        module, metadata, cwd, reqs_by_extra, entrypoints={},
         extra_files=['pyproject.toml']
     )
-    path = sb.build(sdist_directory)
-    return osp.basename(path)
+    path = sb.build(Path(sdist_directory))
+    return path.name
 

--- a/flit_core/flit_core/build_thyself.py
+++ b/flit_core/flit_core/build_thyself.py
@@ -73,7 +73,7 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
             wb.build()
 
         wheel_path = osp.join(wheel_directory, wb.wheel_filename)
-        _replace(temp_path, str(wheel_path))
+        os.replace(temp_path, wheel_path)
     except:
         os.unlink(temp_path)
         raise

--- a/flit_core/flit_core/buildapi.py
+++ b/flit_core/flit_core/buildapi.py
@@ -3,6 +3,7 @@ import logging
 import io
 import os
 import os.path as osp
+from pathlib import Path
 
 from .common import Module, make_metadata, write_entry_points, dist_info_name
 from .config import read_flit_config
@@ -12,7 +13,7 @@ from .sdist import SdistBuilder
 log = logging.getLogger(__name__)
 
 # PEP 517 specifies that the CWD will always be the source tree
-pyproj_toml = 'pyproject.toml'
+pyproj_toml = Path('pyproject.toml')
 
 def get_requires_for_build_wheel(config_settings=None):
     """Returns a list of requirements for building, as strings"""
@@ -25,7 +26,7 @@ get_requires_for_build_sdist = get_requires_for_build_wheel
 def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
     """Creates {metadata_directory}/foo-1.2.dist-info"""
     ini_info = read_flit_config(pyproj_toml)
-    module = Module(ini_info.module, os.getcwd())
+    module = Module(ini_info.module, Path.cwd())
     metadata = make_metadata(module, ini_info)
 
     dist_info = osp.join(metadata_directory,
@@ -46,10 +47,10 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     """Builds a wheel, places it in wheel_directory"""
-    info = make_wheel_in(pyproj_toml, wheel_directory)
-    return osp.basename(info.file)
+    info = make_wheel_in(pyproj_toml, Path(wheel_directory))
+    return info.file.name
 
 def build_sdist(sdist_directory, config_settings=None):
     """Builds an sdist, places it in sdist_directory"""
-    path = SdistBuilder.from_ini_path(pyproj_toml).build(sdist_directory)
-    return osp.basename(path)
+    path = SdistBuilder.from_ini_path(pyproj_toml).build(Path(sdist_directory))
+    return path.name

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -4,8 +4,8 @@ import hashlib
 import logging
 import os
 import os.path as osp
+from pathlib import Path
 import re
-import sys
 
 log = logging.getLogger(__name__)
 
@@ -14,33 +14,33 @@ from .versionno import normalise_version
 class Module(object):
     """This represents the module/package that we are going to distribute
     """
-    def __init__(self, name, directory='.'):
+    def __init__(self, name, directory=Path()):
         self.name = name
         self.directory = directory
 
         # It must exist either as a .py file or a directory, but not both
-        pkg_dir = osp.join(directory, name)
-        py_file = osp.join(directory, name+'.py')
-        src_pkg_dir = osp.join(directory, 'src', name)
-        src_py_file = osp.join(directory, 'src', name+'.py')
+        pkg_dir = directory / name
+        py_file = directory / (name+'.py')
+        src_pkg_dir = directory / 'src' / name
+        src_py_file = directory / 'src' / (name+'.py')
 
         existing = set()
-        if osp.isdir(pkg_dir):
+        if pkg_dir.is_dir():
             self.path = pkg_dir
             self.is_package = True
             self.prefix = ''
             existing.add(pkg_dir)
-        if osp.isfile(py_file):
+        if py_file.is_file():
             self.path = py_file
             self.is_package = False
             self.prefix = ''
             existing.add(py_file)
-        if osp.isdir(src_pkg_dir):
+        if src_pkg_dir.is_dir():
             self.path = src_pkg_dir
             self.is_package = True
             self.prefix = 'src'
             existing.add(src_pkg_dir)
-        if osp.isfile(src_py_file):
+        if src_py_file.is_file():
             self.path = src_py_file
             self.is_package = False
             self.prefix = 'src'
@@ -49,7 +49,7 @@ class Module(object):
         if len(existing) > 1:
             raise ValueError(
                 "Multiple files or folders could be module {}: {}"
-                .format(name, ", ".join(sorted(existing)))
+                .format(name, ", ".join([str(p) for p in sorted(existing)]))
             )
         elif not existing:
             raise ValueError("No file/folder found for module {}".format(name))
@@ -57,12 +57,12 @@ class Module(object):
     @property
     def source_dir(self):
         """Path of folder containing the module (src/ or project root)"""
-        return osp.dirname(self.path)
+        return self.path.parent
 
     @property
     def file(self):
         if self.is_package:
-            return osp.join(self.path, '__init__.py')
+            return self.path / '__init__.py'
         else:
             return self.path
 

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -123,7 +123,7 @@ def get_docstring_and_version_via_ast(target):
     extracted by parsing its AST.
     """
     # read as bytes to enable custom encodings
-    with open(target.file, 'rb') as f:
+    with target.file.open('rb') as f:
         node = ast.parse(f.read())
     for child in node.body:
         # Only use the version from the given module if it's a simple

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -140,31 +140,21 @@ def get_docstring_and_version_via_ast(target):
     return ast.get_docstring(node), version
 
 
-if sys.version_info[0] >= 3:
-    def get_docstring_and_version_via_import(target):
-        """
-        Return a tuple like (docstring, version) for the given module,
-        extracted by importing the module and pulling __doc__ & __version__
-        from it.
-        """
-        log.debug("Loading module %s", target.file)
-        from importlib.machinery import SourceFileLoader
-        sl = SourceFileLoader(target.name, target.file)
-        with _module_load_ctx():
-            m = sl.load_module()
-        docstring = m.__dict__.get('__doc__', None)
-        version = m.__dict__.get('__version__', None)
-        return docstring, version
-else:
-    def get_docstring_and_version_via_import(target):
-        log.debug("Loading module %s", target.file)
-        import imp
-        mod_info = imp.find_module(target.name, [target.source_dir])
-        with _module_load_ctx():
-            m = imp.load_module(target.name, *mod_info)
-        docstring = m.__dict__.get('__doc__', None)
-        version = m.__dict__.get('__version__', None)
-        return docstring, version
+def get_docstring_and_version_via_import(target):
+    """
+    Return a tuple like (docstring, version) for the given module,
+    extracted by importing the module and pulling __doc__ & __version__
+    from it.
+    """
+    log.debug("Loading module %s", target.file)
+    from importlib.machinery import SourceFileLoader
+    sl = SourceFileLoader(target.name, str(target.file))
+    with _module_load_ctx():
+        m = sl.load_module()
+    docstring = m.__dict__.get('__doc__', None)
+    version = m.__dict__.get('__version__', None)
+    return docstring, version
+
 
 def get_info_from_module(target):
     """Load the module/package, get its docstring and __version__

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -89,7 +89,7 @@ class Module(object):
                 dirs[:] = [d for d in sorted(dirs) if _include(d)]
 
         else:
-            yield self.path
+            yield str(self.path)
 
 class ProblemInModule(ValueError): pass
 class NoDocstringError(ProblemInModule): pass

--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -6,19 +6,9 @@ import os
 import os.path as osp
 import pytoml as toml
 import re
-import sys
 
 log = logging.getLogger(__name__)
 
-if sys.version_info[0] >= 3:
-    isidentifier = str.isidentifier
-
-    text_types = (str,)
-else:
-    def isidentifier(s):
-        return bool(re.match('[A-Za-z_][A-Za-z0-9_]*$', s))
-
-    text_types = (str, unicode)
 
 class ConfigError(ValueError):
     pass
@@ -217,7 +207,7 @@ def _prep_metadata(md_sect, path):
     res = LoadedConfig()
 
     res.module = md_sect.get('module')
-    if not isidentifier(res.module):
+    if not str.isidentifier(res.module):
         raise ConfigError("Module name %r is not a valid identifier" % res.module)
 
     md_dict = res.metadata
@@ -270,7 +260,7 @@ def _prep_metadata(md_sect, path):
             if not isinstance(value, list):
                 raise ConfigError('Expected a list for {} field, found {!r}'
                                     .format(key, value))
-            if not all(isinstance(a, text_types) for a in value):
+            if not all(isinstance(a, str) for a in value):
                 raise ConfigError('Expected a list of strings for {} field'
                                     .format(key))
         elif key == 'requires-extra':
@@ -280,11 +270,11 @@ def _prep_metadata(md_sect, path):
             if not all(isinstance(e, list) for e in value.values()):
                 raise ConfigError('Expected a dict of lists for requires-extra field')
             for e, reqs in value.items():
-                if not all(isinstance(a, text_types) for a in reqs):
+                if not all(isinstance(a, str) for a in reqs):
                     raise ConfigError('Expected a string list for requires-extra. (extra {})'
                                         .format(e))
         else:
-            if not isinstance(value, text_types):
+            if not isinstance(value, str):
                 raise ConfigError('Expected a string for {} field, found {!r}'
                                     .format(key, value))
 

--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -1,6 +1,5 @@
 import difflib
 import errno
-import io
 import logging
 import os
 import os.path as osp
@@ -216,9 +215,9 @@ def _prep_metadata(md_sect, path):
     if 'description-file' in md_sect:
         desc_path = md_sect.get('description-file')
         res.referenced_files.append(desc_path)
-        description_file = osp.join(osp.dirname(path), desc_path)
+        description_file = path.parent / desc_path
         try:
-            with io.open(description_file, 'r', encoding='utf-8') as f:
+            with description_file.open('r', encoding='utf-8') as f:
                 raw_desc = f.read()
         except IOError as e:
             if e.errno == errno.ENOENT:
@@ -226,7 +225,7 @@ def _prep_metadata(md_sect, path):
                     "Description file {} does not exist".format(description_file)
                 )
             raise
-        _, ext = osp.splitext(description_file)
+        ext = description_file.suffix
         try:
             mimetype = readme_ext_to_content_type[ext]
         except KeyError:

--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -53,7 +53,7 @@ metadata_required_fields = {
 def read_flit_config(path):
     """Read and check the `pyproject.toml` file with data about the package.
     """
-    with io.open(path, 'r', encoding='utf-8') as f:
+    with path.open('r', encoding='utf-8') as f:
         d = toml.load(f)
     return prep_toml_config(d, path)
 

--- a/flit_core/flit_core/sdist.py
+++ b/flit_core/flit_core/sdist.py
@@ -182,7 +182,7 @@ class SdistBuilder:
             files_to_add = self.apply_includes_excludes(self.select_files())
 
             for relpath in files_to_add:
-                path = osp.join(self.cfgdir, relpath)
+                path = str(self.cfgdir / relpath)
                 ti = tf.gettarinfo(path, arcname=pjoin(self.dir_name, relpath))
                 ti = clean_tarinfo(ti, mtime)
 

--- a/flit_core/flit_core/sdist.py
+++ b/flit_core/flit_core/sdist.py
@@ -137,7 +137,7 @@ class SdistBuilder:
                 files.add(f_rel)
 
         for rel_d in self.includes.dirs:
-            for dirpath, dirs, dfiles in os.walk(osp.join(self.cfgdir, rel_d)):
+            for dirpath, dirs, dfiles in os.walk(osp.join(cfgdir_s, rel_d)):
                 for file in dfiles:
                     f_abs = osp.join(dirpath, file)
                     f_rel = osp.relpath(f_abs, cfgdir_s)

--- a/flit_core/flit_core/tests/test_common.py
+++ b/flit_core/flit_core/tests/test_common.py
@@ -1,24 +1,24 @@
-import os.path as osp
-from unittest import TestCase
+from pathlib import Path
 import pytest
+from unittest import TestCase
 
 from flit_core.common import (
     Module, get_info_from_module, InvalidVersion, NoVersionError, check_version,
     normalize_file_permissions, Metadata
 )
 
-samples_dir = osp.join(osp.dirname(__file__), 'samples')
+samples_dir = Path(__file__).parent / 'samples'
 
 class ModuleTests(TestCase):
     def test_package_importable(self):
         i = Module('package1', samples_dir)
-        assert i.path == osp.join(samples_dir, 'package1')
-        assert i.file == osp.join(samples_dir, 'package1', '__init__.py')
+        assert i.path == samples_dir / 'package1'
+        assert i.file == samples_dir / 'package1' / '__init__.py'
         assert i.is_package
 
     def test_module_importable(self):
         i = Module('module1', samples_dir)
-        assert i.path == osp.join(samples_dir, 'module1.py')
+        assert i.path == samples_dir / 'module1.py'
         assert not i.is_package
 
     def test_missing_name(self):
@@ -27,7 +27,7 @@ class ModuleTests(TestCase):
 
     def test_conflicting_modules(self):
         with pytest.raises(ValueError, match="Multiple"):
-            Module('module1', osp.join(samples_dir, 'conflicting_modules'))
+            Module('module1', samples_dir / 'conflicting_modules')
 
     def test_get_info_from_module(self):
         info = get_info_from_module(Module('module1', samples_dir))

--- a/flit_core/flit_core/tests/test_config.py
+++ b/flit_core/flit_core/tests/test_config.py
@@ -1,44 +1,44 @@
 import logging
-import os.path as osp
+from pathlib import Path
 import pytest
 
 from flit_core import config
 
-samples_dir = osp.join(osp.dirname(__file__), 'samples')
+samples_dir = Path(__file__).parent / 'samples'
 
 def test_flatten_entrypoints():
     r = config.flatten_entrypoints({'a': {'b': {'c': 'd'}, 'e': {'f': {'g': 'h'}}, 'i': 'j'}})
     assert r == {'a': {'i': 'j'}, 'a.b': {'c': 'd'}, 'a.e.f': {'g': 'h'}}
 
 def test_load_toml():
-    inf = config.read_flit_config(osp.join(samples_dir, 'module1-pkg.toml'))
+    inf = config.read_flit_config(samples_dir / 'module1-pkg.toml')
     assert inf.module == 'module1'
     assert inf.metadata['home_page'] == 'http://github.com/sirrobin/module1'
 
 def test_misspelled_key():
     with pytest.raises(config.ConfigError) as e_info:
-        config.read_flit_config(osp.join(samples_dir, 'misspelled-key.toml'))
+        config.read_flit_config(samples_dir / 'misspelled-key.toml')
 
     assert 'description-file' in str(e_info.value)
 
 def test_description_file():
-    info = config.read_flit_config(osp.join(samples_dir, 'package1.toml'))
+    info = config.read_flit_config(samples_dir / 'package1.toml')
     assert info.metadata['description'] == \
         "Sample description for test.\n"
     assert info.metadata['description_content_type'] == 'text/x-rst'
 
 def test_missing_description_file():
     with pytest.raises(config.ConfigError, match=r"Description file .* does not exist"):
-        config.read_flit_config(osp.join(samples_dir, 'missing-description-file.toml'))
+        config.read_flit_config(samples_dir / 'missing-description-file.toml')
 
 def test_bad_description_extension(caplog):
-    info = config.read_flit_config(osp.join(samples_dir, 'bad-description-ext.toml'))
+    info = config.read_flit_config(samples_dir / 'bad-description-ext.toml')
     assert info.metadata['description_content_type'] is None
     assert any((r.levelno == logging.WARN and "Unknown extension" in r.msg)
                 for r in caplog.records)
 
 def test_extras():
-    info = config.read_flit_config(osp.join(samples_dir, 'extras.toml'))
+    info = config.read_flit_config(samples_dir / 'extras.toml')
     requires_dist = set(info.metadata['requires_dist'])
     assert requires_dist == {
         'toml',
@@ -49,15 +49,15 @@ def test_extras():
 
 def test_extras_dev_conflict():
     with pytest.raises(config.ConfigError, match=r'dev-requires'):
-        config.read_flit_config(osp.join(samples_dir, 'extras-dev-conflict.toml'))
+        config.read_flit_config(samples_dir / 'extras-dev-conflict.toml')
 
 def test_extras_dev_warning(caplog):
-    info = config.read_flit_config(osp.join(samples_dir, 'requires-dev.toml'))
+    info = config.read_flit_config(samples_dir / 'requires-dev.toml')
     assert '"dev-requires = ..." is obsolete' in caplog.text
     assert set(info.metadata['requires_dist']) == {'apackage ; extra == "dev"'}
 
 def test_requires_extra_env_marker():
-    info = config.read_flit_config(osp.join(samples_dir, 'requires-extra-envmark.toml'))
+    info = config.read_flit_config(samples_dir / 'requires-extra-envmark.toml')
     assert info.metadata['requires_dist'][0].startswith('pathlib2 ;')
 
 @pytest.mark.parametrize(('erroneous', 'match'), [

--- a/flit_core/flit_core/tests/test_sdist.py
+++ b/flit_core/flit_core/tests/test_sdist.py
@@ -1,24 +1,23 @@
 from io import BytesIO
 import os.path as osp
+from pathlib import Path
 import tarfile
 from testpath import assert_isfile
-from testpath.tempdir import TemporaryDirectory
 
 from flit_core import sdist
 
-samples_dir = osp.join(osp.dirname(__file__), 'samples')
+samples_dir = Path(__file__).parent / 'samples'
 
-def test_make_sdist():
+def test_make_sdist(tmp_path):
     # Smoke test of making a complete sdist
-    builder = sdist.SdistBuilder.from_ini_path(osp.join(samples_dir, 'package1.toml'))
-    with TemporaryDirectory() as td:
-        builder.build(td)
-        assert_isfile(osp.join(td, 'package1-0.1.tar.gz'))
+    builder = sdist.SdistBuilder.from_ini_path(samples_dir / 'package1.toml')
+    builder.build(tmp_path)
+    assert_isfile(tmp_path / 'package1-0.1.tar.gz')
 
 
 def test_clean_tarinfo():
     with tarfile.open(mode='w', fileobj=BytesIO()) as tf:
-        ti = tf.gettarinfo(osp.join(samples_dir, 'module1.py'))
+        ti = tf.gettarinfo(str(samples_dir / 'module1.py'))
     cleaned = sdist.clean_tarinfo(ti, mtime=42)
     assert cleaned.uid == 0
     assert cleaned.uname == ''
@@ -27,7 +26,7 @@ def test_clean_tarinfo():
 
 def test_include_exclude():
     builder = sdist.SdistBuilder.from_ini_path(
-        osp.join(samples_dir, 'inclusion', 'pyproject.toml')
+        samples_dir / 'inclusion' / 'pyproject.toml'
     )
     files = builder.apply_includes_excludes(builder.select_files())
 

--- a/flit_core/flit_core/wheel.py
+++ b/flit_core/flit_core/wheel.py
@@ -80,7 +80,7 @@ class WheelBuilder:
     def from_ini_path(cls, ini_path, target_fp):
         # Local import so bootstrapping doesn't try to load pytoml
         from .config import read_flit_config
-        directory = osp.dirname(ini_path)
+        directory = ini_path.parent
         ini_info = read_flit_config(ini_path)
         entrypoints = ini_info.entrypoints
         module = common.Module(ini_info.module, directory)
@@ -229,8 +229,8 @@ def make_wheel_in(ini_path, wheel_directory):
             wb = WheelBuilder.from_ini_path(ini_path, fp)
             wb.build()
 
-        wheel_path = osp.join(wheel_directory, wb.wheel_filename)
         _replace(temp_path, str(wheel_path))
+        wheel_path = wheel_directory / wb.wheel_filename
     except:
         os.unlink(temp_path)
         raise

--- a/flit_core/flit_core/wheel.py
+++ b/flit_core/flit_core/wheel.py
@@ -180,7 +180,7 @@ class WheelBuilder:
 
     def copy_module(self):
         log.info('Copying package file(s) from %s', self.module.path)
-        source_dir = self.module.source_dir
+        source_dir = str(self.module.source_dir)
 
         for full_path in self.module.iter_files():
             rel_path = osp.relpath(full_path, source_dir)

--- a/flit_core/flit_core/wheel.py
+++ b/flit_core/flit_core/wheel.py
@@ -194,7 +194,7 @@ class WheelBuilder:
                 common.write_entry_points(self.entrypoints, f)
 
         for base in ('COPYING', 'LICENSE'):
-            for path in sorted(glob(str(self.directory / base + '*'))):
+            for path in sorted(glob(str(self.directory / (base + '*')))):
                 self._add_file(path, '%s/%s' % (self.dist_info, osp.basename(path)))
 
         with self._write_to_zip(self.dist_info + '/WHEEL') as f:

--- a/flit_core/flit_core/wheel.py
+++ b/flit_core/flit_core/wheel.py
@@ -229,20 +229,11 @@ def make_wheel_in(ini_path, wheel_directory):
             wb = WheelBuilder.from_ini_path(ini_path, fp)
             wb.build()
 
-        _replace(temp_path, str(wheel_path))
         wheel_path = wheel_directory / wb.wheel_filename
+        os.replace(temp_path, str(wheel_path))
     except:
         os.unlink(temp_path)
         raise
 
     log.info("Built wheel: %s", wheel_path)
     return SimpleNamespace(builder=wb, file=wheel_path)
-
-
-if sys.version_info[0] >= 3:
-    _replace = os.replace
-else:
-    def _replace(src, dst):
-        if os.path.exists(dst):
-            os.unlink(dst)
-        os.rename(src, dst)

--- a/flit_core/flit_core/wheel.py
+++ b/flit_core/flit_core/wheel.py
@@ -194,7 +194,7 @@ class WheelBuilder:
                 common.write_entry_points(self.entrypoints, f)
 
         for base in ('COPYING', 'LICENSE'):
-            for path in sorted(glob(osp.join(self.directory, base + '*'))):
+            for path in sorted(glob(str(self.directory / base + '*'))):
                 self._add_file(path, '%s/%s' % (self.dist_info, osp.basename(path)))
 
         with self._write_to_zip(self.dist_info + '/WHEEL') as f:

--- a/tox.ini
+++ b/tox.ini
@@ -29,10 +29,6 @@ commands =
 commands =
     python -m pytest --cov=flit_core/flit_core --pyargs flit_core
 
-[testenv:py27]
-commands =
-    python -m pytest --cov=flit_core/flit_core --pyargs flit_core
-
 [testenv:bootstrap]
 skip_install = true
 # Make the install step a no-op, so nothing gets installed in the env


### PR DESCRIPTION
For Flit 3, we're going back to requiring Python 3. It will still be possible to install projects from source on Python 2, because pip will find a 2.x version of `flit_core` to use.

There's still some messiness with using pathlib before Python 3.6, when lots of APIs started to accept Path objects.