### PR TITLE
Update generated scripts to match pip installed scripts

### DIFF
--- a/flit/install.py
+++ b/flit/install.py
@@ -171,13 +171,14 @@ class Installer(object):
 
     def install_scripts(self, script_defs, scripts_dir):
         for name, ep in script_defs.items():
-            module, func = common.parse_entry_point(ep)
+            module, import_name, func = common.parse_entry_point(ep)
             script_file = pathlib.Path(scripts_dir) / name
             log.info('Writing script to %s', script_file)
             with script_file.open('w', encoding='utf-8') as f:
                 f.write(common.script_template.format(
                     interpreter=self.python,
                     module=module,
+                    import_name=import_name,
                     func=func
                 ))
             script_file.chmod(0o755)

--- a/flit/install.py
+++ b/flit/install.py
@@ -171,7 +171,8 @@ class Installer(object):
 
     def install_scripts(self, script_defs, scripts_dir):
         for name, ep in script_defs.items():
-            module, import_name, func = common.parse_entry_point(ep)
+            module, func = common.parse_entry_point(ep)
+            import_name = func.split('.')[0]
             script_file = pathlib.Path(scripts_dir) / name
             log.info('Writing script to %s', script_file)
             with script_file.open('w', encoding='utf-8') as f:

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -209,27 +209,32 @@ def check_version(version):
 
 script_template = """\
 #!{interpreter}
-from {module} import {func}
+# -*- coding: utf-8 -*-
+import re
+import sys
+from {module} import {import_name}
 if __name__ == '__main__':
-    {func}()
+    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
+    sys.exit({func}())
 """
 
 def parse_entry_point(ep):
     """Check and parse a 'package.module:func' style entry point specification.
 
-    Returns (modulename, funcname)
+    Returns (modulename, import_name, funcname)
     """
     if ':' not in ep:
         raise ValueError("Invalid entry point (no ':'): %r" % ep)
     mod, func = ep.split(':')
 
-    if not func.isidentifier():
-        raise ValueError("Invalid entry point: %r is not an identifier" % func)
+    for piece in func.split('.'):
+        if not piece.isidentifier():
+            raise ValueError("Invalid entry point: %r is not an identifier" % piece)
     for piece in mod.split('.'):
         if not piece.isidentifier():
             raise ValueError("Invalid entry point: %r is not a module path" % piece)
 
-    return mod, func
+    return mod, func.split('.')[0], func
 
 def write_entry_points(d, fp):
     """Write entry_points.txt from a two-level dict

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -221,7 +221,7 @@ if __name__ == '__main__':
 def parse_entry_point(ep):
     """Check and parse a 'package.module:func' style entry point specification.
 
-    Returns (modulename, import_name, funcname)
+    Returns (modulename, funcname)
     """
     if ':' not in ep:
         raise ValueError("Invalid entry point (no ':'): %r" % ep)

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -234,7 +234,7 @@ def parse_entry_point(ep):
         if not piece.isidentifier():
             raise ValueError("Invalid entry point: %r is not a module path" % piece)
 
-    return mod, func.split('.')[0], func
+    return mod, func
 
 def write_entry_points(d, fp):
     """Write entry_points.txt from a two-level dict

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -214,7 +214,7 @@ import re
 import sys
 from {module} import {import_name}
 if __name__ == '__main__':
-    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
+    sys.argv[0] = re.sub(r'(-script\\.pyw|\\.exe)?$', '', sys.argv[0])
     sys.exit({func}())
 """
 


### PR DESCRIPTION
I have some console scripts which are class methods (the main remains the same, but I have a hierarchy of subclasses in different packages which fill out functionality for several different entry points)

```
[tool.flit.scripts]
foo="bar.baz:Spam.main"
```

This caused flit to fail when doing editable installs (symlink/pth-file), but work when doing "regular" installs (via pip)

I found that the template used here expected _only_ a single part function call.

This PR takes the [template as used by pip (provided by the vendored distlib)](https://github.com/pypa/pip/blob/master/src/pip/_vendor/distlib/scripts.py#L41) and modifies the functions that interact with the template to provide the imported name separate from the function name.