### PR TITLE
add spaces to warning about missing __version__

### DIFF
--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -196,7 +196,7 @@ def check_version(version):
     """
     if not version:
         raise NoVersionError('Cannot package module without a version string. '
-                             'Please define a `__version__="x.y.z"` in your module.')
+                             'Please define a `__version__ = "x.y.z"` in your module.')
     if not isinstance(version, str):
         raise InvalidVersion('__version__ must be a string, not {}.'
                                 .format(type(version)))


### PR DESCRIPTION
Because a likely reaction to this useful warning is to copy paste this into the module and adjust x, y, and z but then it's convenient to not have to add spaces in addition.