### PR TITLE
Deterministically produce RECORD file

### DIFF
--- a/flit/install.py
+++ b/flit/install.py
@@ -392,7 +392,7 @@ class Installer(object):
 
         with (dist_info / 'RECORD').open('w', encoding='utf-8') as f:
             cf = csv.writer(f)
-            for path in self.installed_files:
+            for path in sorted(self.installed_files, key=lambda s: str(s)):
                 path = pathlib.Path(path)
                 if path.is_symlink() or path.suffix in {'.pyc', '.pyo'}:
                     hash, size = '', ''

--- a/flit/install.py
+++ b/flit/install.py
@@ -392,7 +392,7 @@ class Installer(object):
 
         with (dist_info / 'RECORD').open('w', encoding='utf-8') as f:
             cf = csv.writer(f)
-            for path in sorted(self.installed_files, key=lambda s: str(s)):
+            for path in sorted(self.installed_files, key=str):
                 path = pathlib.Path(path)
                 if path.is_symlink() or path.suffix in {'.pyc', '.pyo'}:
                     hash, size = '', ''


### PR DESCRIPTION
Hi,

While working on a Debian package that uses flit, I noticed that the package could not be built reproducibly (https://reproducible-builds.org).

This patch will aid to reproducibly build Debian packages of projects that use flit.