### PR TITLE
Allow modules to stub themselves out

### DIFF
--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -112,10 +112,12 @@ def _module_load_ctx():
     - Handlers on the root logger.
     """
     logging_handlers = logging.root.handlers[:]
+    os.environ["FLIT_GETTING_VERSION"] = "1"
     try:
         yield
     finally:
         logging.root.handlers = logging_handlers
+        del os.environ["FLIT_GETTING_VERSION"]
 
 def get_docstring_and_version_via_ast(target):
     """


### PR DESCRIPTION
I currently rely on a hack to enable flit to get the version of a module with no dependencies installed.

This patch would allow me to just use `if not os.environ.get('FLIT_GETTING_VERSION'): ...`

`pkg/_metadata.py`

```py
import traceback
from get_version import get_version
__version__ = get_version(__file__.replace('_metadata', '__init__'))

def within_flit():
    import traceback
    for frame in traceback.extract_stack():
        if frame.name == 'get_docstring_and_version_via_import':
            return True
    return False
```

`pkg/__init__.py`:

```py
"""Your package docstring"""
	   
from ._metadata import __version__, within_flit
	   
if not within_flit():
    from .subpackage import thing
```