### PR TITLE
Allow + in wheel filenames

### DIFF
--- a/flit_core/flit_core/wheel.py
+++ b/flit_core/flit_core/wheel.py
@@ -101,7 +101,7 @@ class WheelBuilder:
         tag = ('py2.' if self.metadata.supports_py2 else '') + 'py3-none-any'
         return '{}-{}-{}.whl'.format(
                 re.sub(r"[^\w\d.]+", "_", self.metadata.name, flags=re.UNICODE),
-                re.sub(r"[^\w\d.]+", "_", self.metadata.version, flags=re.UNICODE),
+                re.sub(r"[^\w\d\+.]+", "_", self.metadata.version, flags=re.UNICODE),
                 tag)
 
     def _add_file_old(self, full_path, rel_path):


### PR DESCRIPTION
The latest releases of pip (released today, v20.3.4 and v21.0) add a verification step which checks the info in the generated filename against the package. (pypa/pip#9320,  specifically [these lines](https://github.com/pypa/pip/blob/c7419b2aac16c1190b274b9cd7c273d879816ddb/src/pip/_internal/wheel_builder.py#L200-L204))

This caused versions with extra info (e.g. git branch) appended to the version using `+` to fail the check, since flit replaces all non alphanumeric characters with `_` in the filename (the actual metadata still has the plus sign, but the check is against the filename).

I checked against behavior of setuptools, which retains `+` in the filename of the wheel.

This simply allows the `+` character in the version part of the filename (I believe it is not allowed in the package name itself)

As to whether a filename with an `_` in place of `+` _should_ fail such a verification, I'm not totally convinced, but it is easy enough to allow the character.