### PR TITLE
PEP 660 support

### DIFF
--- a/flit/wheel.py
+++ b/flit/wheel.py
@@ -4,8 +4,8 @@ import flit_core.wheel as core_wheel
 
 log = logging.getLogger(__name__)
 
-def make_wheel_in(ini_path, wheel_directory):
-    return core_wheel.make_wheel_in(ini_path, wheel_directory)
+def make_wheel_in(ini_path, wheel_directory, editable=False):
+    return core_wheel.make_wheel_in(ini_path, wheel_directory, editable)
 
 class WheelBuilder(core_wheel.WheelBuilder):
     pass

--- a/flit_core/flit_core/buildapi.py
+++ b/flit_core/flit_core/buildapi.py
@@ -39,6 +39,9 @@ def get_requires_for_build_wheel(config_settings=None):
 # Requirements to build an sdist are the same as for a wheel
 get_requires_for_build_sdist = get_requires_for_build_wheel
 
+# Requirements to build an editable are the same as for a wheel
+get_requires_for_build_editable = get_requires_for_build_wheel
+
 def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
     """Creates {metadata_directory}/foo-1.2.dist-info"""
     ini_info = read_flit_config(pyproj_toml)
@@ -61,9 +64,17 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
 
     return osp.basename(dist_info)
 
+# Metadata for editable are the same as for a wheel
+prepare_metadata_for_build_editable = prepare_metadata_for_build_wheel
+
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     """Builds a wheel, places it in wheel_directory"""
     info = make_wheel_in(pyproj_toml, Path(wheel_directory))
+    return info.file.name
+
+def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
+    """Builds an "editable" wheel, places it in wheel_directory"""
+    info = make_wheel_in(pyproj_toml, Path(wheel_directory), editable=True)
     return info.file.name
 
 def build_sdist(sdist_directory, config_settings=None):

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -25,10 +25,32 @@ def test_wheel_module(copy_sample):
     make_wheel_in(td / 'pyproject.toml', td)
     assert_isfile(td / 'module1-0.1-py2.py3-none-any.whl')
 
+def test_editable_wheel_module(copy_sample):
+    td = copy_sample('module1_toml')
+    make_wheel_in(td / 'pyproject.toml', td, editable=True)
+    whl_file = td / 'module1-0.1-py2.py3-none-any.whl'
+    assert_isfile(whl_file)
+    with unpack(whl_file) as unpacked:
+        pth_path = Path(unpacked, 'module1.pth')
+        assert_isfile(pth_path)
+        assert pth_path.read_text() == str(td)
+        assert_isdir(Path(unpacked, 'module1-0.1.dist-info'))
+
 def test_wheel_package(copy_sample):
     td = copy_sample('package1')
     make_wheel_in(td / 'pyproject.toml', td)
     assert_isfile(td / 'package1-0.1-py2.py3-none-any.whl')
+
+def test_editable_wheel_package(copy_sample):
+    td = copy_sample('package1')
+    make_wheel_in(td / 'pyproject.toml', td, editable=True)
+    whl_file = td / 'package1-0.1-py2.py3-none-any.whl'
+    assert_isfile(whl_file)
+    with unpack(whl_file) as unpacked:
+        pth_path = Path(unpacked, 'package1.pth')
+        assert_isfile(pth_path)
+        assert pth_path.read_text() == str(td)
+        assert_isdir(Path(unpacked, 'package1-0.1.dist-info'))
 
 def test_wheel_src_module(copy_sample):
     td = copy_sample('module3')
@@ -41,6 +63,17 @@ def test_wheel_src_module(copy_sample):
         assert_isdir(Path(unpacked, 'module3-0.1.dist-info'))
         assert_isfile(Path(unpacked, 'module3-0.1.dist-info', 'LICENSE'))
 
+def test_editable_wheel_src_module(copy_sample):
+    td = copy_sample('module3')
+    make_wheel_in(td / 'pyproject.toml', td, editable=True)
+    whl_file = td / 'module3-0.1-py2.py3-none-any.whl'
+    assert_isfile(whl_file)
+    with unpack(whl_file) as unpacked:
+        pth_path = Path(unpacked, 'module3.pth')
+        assert_isfile(pth_path)
+        assert pth_path.read_text() == str(td / "src")
+        assert_isdir(Path(unpacked, 'module3-0.1.dist-info'))
+
 def test_wheel_src_package(copy_sample):
     td = copy_sample('package2')
     make_wheel_in(td / 'pyproject.toml', td)
@@ -50,6 +83,18 @@ def test_wheel_src_package(copy_sample):
     with unpack(whl_file) as unpacked:
         print(os.listdir(unpacked))
         assert_isfile(Path(unpacked, 'package2', '__init__.py'))
+
+def test_editable_wheel_src_package(copy_sample):
+    td = copy_sample('package2')
+    make_wheel_in(td / 'pyproject.toml', td, editable=True)
+    whl_file = td / 'package2-0.1-py2.py3-none-any.whl'
+    assert_isfile(whl_file)
+    with unpack(whl_file) as unpacked:
+        pth_path = Path(unpacked, 'package2.pth')
+        assert_isfile(pth_path)
+        assert pth_path.read_text() == str(td / "src")
+        assert_isdir(Path(unpacked, 'package2-0.1.dist-info'))
+
 
 def test_dist_name(copy_sample):
     td = copy_sample('altdistname')


### PR DESCRIPTION
This is a very rough proof of concept for `build_wheel_for_editable`, as described in https://discuss.python.org/t/standardising-editable-mode-installs-runtime-layout-not-hooks/4098/55 and prototyped in https://github.com/pypa/pip/pull/8212. 

It works by adding a `.pth` file in the transient wheel, and should therefore behave identically as `flit install --pth-file`.