### PR TITLE
Support SHA256 hashes

### DIFF
--- a/flit/upload.py
+++ b/flit/upload.py
@@ -226,6 +226,7 @@ def upload_file(file:Path, metadata:Metadata, repo):
         content = f.read()
         files = {'content': (file.name, content)}
         data['md5_digest'] = hashlib.md5(content).hexdigest()
+        data['sha256_digest'] = hashlib.sha256(content).hexdigest()
 
     log.info('Uploading %s...', file)
     resp = requests.post(repo['url'],


### PR DESCRIPTION
Hi friend!

This is needed by GitLab to support uploads from flit (GitLab works fine with twine).

Addresses #364 of takluyver/flit
Addresses [#333964 of gitlab.com/gitlab-org/gitlab](https://gitlab.com/gitlab-org/gitlab/-/issues/333964)

The most useful one-line of code I ever wrote I believe. If this is merged, we will be able to use gitlab as a fully functional pip repository that works with flit. 

Cheers!
Matcha