### PR TITLE
Pin attrs <21 for testing on Python 3.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,9 @@ deps =
     py35: zipfile36
     py34: zipfile36
 
+    # pytest requires attrs, and it now gets a version for Py >= 3.5 by default
+    py34: attrs <21
+
 skip_install=true
 
 setenv =


### PR DESCRIPTION
Tests failed on PR #416 for Python 3.4, because it got a version of `attrs` that was too new.

In fact the offending release has been yanked (see https://github.com/python-attrs/attrs/pull/807 )... but it seems that the version of pip which supports Python 3.4 is too old to know about yanking, so it needs this workaround.