### PR TITLE
Fix installing dependencies specified in [project] table

### DIFF
--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -551,7 +551,9 @@ def read_pep621_metadata(proj, path) -> LoadedConfig:
 
     if 'dependencies' in proj:
         _check_list_of_str(proj, 'dependencies')
-        md_dict['requires_dist'] = proj['dependencies']
+        reqs_noextra = proj['dependencies']
+    else:
+        reqs_noextra = []
 
     if 'optional-dependencies' in proj:
         _check_type(proj, 'optional-dependencies', dict)
@@ -566,16 +568,14 @@ def read_pep621_metadata(proj, path) -> LoadedConfig:
                     'Expected a string list for optional-dependencies ({})'.format(e)
                 )
 
-        reqs_noextra = md_dict.pop('requires_dist', [])
         lc.reqs_by_extra = optdeps.copy()
-
-        # Add optional-dependencies into requires_dist
-        md_dict['requires_dist'] = \
-            reqs_noextra + list(_expand_requires_extra(lc.reqs_by_extra))
-
         md_dict['provides_extra'] = sorted(lc.reqs_by_extra.keys())
 
-        # For internal use, record the main requirements as a '.none' extra.
+    md_dict['requires_dist'] = \
+        reqs_noextra + list(_expand_requires_extra(lc.reqs_by_extra))
+
+    # For internal use, record the main requirements as a '.none' extra.
+    if reqs_noextra:
         lc.reqs_by_extra['.none'] = reqs_noextra
 
     if 'dynamic' in proj:

--- a/flit_core/flit_core/tests/samples/pep621_nodynamic/pyproject.toml
+++ b/flit_core/flit_core/tests/samples/pep621_nodynamic/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
     "requests >= 2.18",
     "docutils",
-]
+]  # N.B. Using this to check behaviour with dependencies but no optional deps
 
 [project.urls]
 homepage = "http://github.com/sirrobin/module1"

--- a/flit_core/flit_core/tests/test_config.py
+++ b/flit_core/flit_core/tests/test_config.py
@@ -39,6 +39,10 @@ def test_load_pep621_nodynamic():
     assert inf.metadata['summary'] == 'Statically specified description'
     assert set(inf.dynamic_metadata) == set()
 
+    # Filling reqs_by_extra when dependencies were specified but no optional
+    # dependencies was a bug.
+    assert inf.reqs_by_extra == {'.none':  ['requests >= 2.18', 'docutils']}
+
 def test_misspelled_key():
     with pytest.raises(config.ConfigError) as e_info:
         config.read_flit_config(samples_dir / 'misspelled-key.toml')


### PR DESCRIPTION
The code loading the config file was doing the wrong thing when `dependencies` were specified but not `optional-dependencies`.

Closes #432.