### PR TITLE
Add custom pypirc support

### DIFF
--- a/doc/cmdline.rst
+++ b/doc/cmdline.rst
@@ -73,7 +73,7 @@ or another repository.
 
 .. option:: --pypirc <pypirc>
 
-   The .pypirc config file to be used. DEFAULT = "~/.pypirc"
+   The .pypirc config file to be used. The default is ``~/.pypirc``.
 
 .. seealso:: :doc:`upload`
 

--- a/doc/cmdline.rst
+++ b/doc/cmdline.rst
@@ -71,6 +71,10 @@ or another repository.
    Name of a repository to upload packages to. Should match a section in
    ``~/.pypirc``. The default is ``pypi``.
 
+.. option:: --pypirc <pypirc>
+
+   The .pypirc config file to be used. DEFAULT = "~/.pypirc"
+
 .. seealso:: :doc:`upload`
 
 .. _install_cmd:

--- a/doc/history.rst
+++ b/doc/history.rst
@@ -316,8 +316,8 @@ Version 0.11
 
   - If you have the `keyring <https://github.com/jaraco/keyring>`_ package
     installed, flit can use it to store your password, rather than keeping it
-    in plain text in ``~/.pypirc``.
-  - If ``~/.pypirc`` does not already exist, and you are prompted for your
+    in plain text in the .pypirc file.
+  - If the .pypirc file does not already exist, and you are prompted for your
     username, flit will write it into that file.
   - You can provide the information as environment variables:
     :envvar:`FLIT_USERNAME`, :envvar:`FLIT_PASSWORD` and :envvar:`FLIT_INDEX_URL`.

--- a/doc/history.rst
+++ b/doc/history.rst
@@ -316,8 +316,8 @@ Version 0.11
 
   - If you have the `keyring <https://github.com/jaraco/keyring>`_ package
     installed, flit can use it to store your password, rather than keeping it
-    in plain text in the .pypirc file.
-  - If the .pypirc file does not already exist, and you are prompted for your
+    in plain text in ``~/.pypirc``.
+  - If ``~/.pypirc`` does not already exist, and you are prompted for your
     username, flit will write it into that file.
   - You can provide the information as environment variables:
     :envvar:`FLIT_USERNAME`, :envvar:`FLIT_PASSWORD` and :envvar:`FLIT_INDEX_URL`.

--- a/doc/upload.rst
+++ b/doc/upload.rst
@@ -14,7 +14,8 @@ you can configure Flit in two main ways:
 Using .pypirc
 -------------
 
-You can create or edit a config file in your home directory, ``~/.pypirc``.
+You can create or edit a config file in your home directory, ``~/.pypirc`` that
+will be used by default or you can specify a custom location.
 This is also used by other Python tools such as `twine
 <https://pypi.python.org/pypi/twine>`_.
 

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -116,6 +116,10 @@ def main(argv=None):
              )
     )
 
+    parser_publish.add_argument('--pypirc', default="~/.pypirc",
+        help="Path for .pypirc file."
+    )
+
     parser_publish.add_argument('--repository',
         help="Name of the repository to upload to (must be in ~/.pypirc)"
     )
@@ -184,7 +188,7 @@ def main(argv=None):
             log.warning("Passing --repository before the 'upload' subcommand is deprecated: pass it after")
         repository = args.repository or args.deprecated_repository
         from .upload import main
-        main(args.ini_file, repository, formats=set(args.format or []),
+        main(args.ini_file, repository, args.pypirc, formats=set(args.format or []),
                 gen_setup_py=gen_setup_py())
 
     elif args.subcmd == 'install':

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -117,11 +117,11 @@ def main(argv=None):
     )
 
     parser_publish.add_argument('--pypirc', default="~/.pypirc",
-        help="Path for .pypirc file."
+        help="The .pypirc config file to be used. DEFAULT = \"~/.pypirc\""
     )
 
     parser_publish.add_argument('--repository',
-        help="Name of the repository to upload to (must be in ~/.pypirc)"
+        help="Name of the repository to upload to (must be in the specified .pypirc file)"
     )
 
     # flit install --------------------------------------------

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -116,7 +116,7 @@ def main(argv=None):
              )
     )
 
-    parser_publish.add_argument('--pypirc', default="~/.pypirc",
+    parser_publish.add_argument('--pypirc',
         help="The .pypirc config file to be used. DEFAULT = \"~/.pypirc\""
     )
 

--- a/flit/upload.py
+++ b/flit/upload.py
@@ -242,7 +242,7 @@ def upload_file(file:Path, metadata:Metadata, repo):
 def do_upload(file:Path, metadata:Metadata, pypirc_path:Path, repo_name=None):
     """Upload a file to an index server.
     """
-    repo = get_repository(repo_name, pypirc_path)
+    repo = get_repository(pypirc_path, repo_name)
     upload_file(file, metadata, repo)
 
     if repo['is_warehouse']:

--- a/flit/upload.py
+++ b/flit/upload.py
@@ -18,6 +18,7 @@ from flit_core.common import Metadata
 log = logging.getLogger(__name__)
 
 PYPI = "https://upload.pypi.org/legacy/"
+PYPIRC_DEFAULT = "~/.pypirc"
 
 SWITCH_TO_HTTPS = (
     "http://pypi.python.org/",
@@ -255,6 +256,11 @@ def do_upload(file:Path, metadata:Metadata, pypirc_path, repo_name=None):
 
 def main(ini_path, repo_name, pypirc_path, formats=None, gen_setup_py=True):
     """Build and upload wheel and sdist."""
+    if pypirc_path is None:
+        pypirc_path = PYPIRC_DEFAULT
+    elif not os.path.isfile(pypirc_path):
+        raise FileNotFoundError("The specified pypirc config file does not exist.")
+
     from . import build
     built = build.main(ini_path, formats=formats, gen_setup_py=gen_setup_py)
 

--- a/flit/upload.py
+++ b/flit/upload.py
@@ -27,7 +27,7 @@ SWITCH_TO_HTTPS = (
     "http://upload.pypi.io/",
 )
 
-def get_repositories(file):
+def get_repositories(file="~/.pypirc"):
     """Get the known repositories from a pypirc file.
 
     This returns a dict keyed by name, of dicts with keys 'url', 'username',
@@ -60,7 +60,7 @@ def get_repositories(file):
     return repos
 
 
-def get_repository(pypirc_path, name=None):
+def get_repository(pypirc_path="~/.pypirc", name=None):
     """Get the url, username and password for one repository.
 
     Returns a dict with keys 'url', 'username', 'password'.
@@ -126,7 +126,7 @@ def get_repository(pypirc_path, name=None):
 
     return repo
 
-def write_pypirc(repo, file):
+def write_pypirc(repo, file="~/.pypirc"):
     """Write .pypirc if it doesn't already exist
     """
     file = os.path.expanduser(file)
@@ -239,7 +239,7 @@ def upload_file(file:Path, metadata:Metadata, repo):
     resp.raise_for_status()
 
 
-def do_upload(file:Path, metadata:Metadata, pypirc_path, repo_name=None):
+def do_upload(file:Path, metadata:Metadata, pypirc_path="~/.pypirc", repo_name=None):
     """Upload a file to an index server.
     """
     repo = get_repository(pypirc_path, repo_name)

--- a/flit/upload.py
+++ b/flit/upload.py
@@ -85,9 +85,8 @@ def get_repository(pypirc_path, name=None):
     3. keyring
     4. Terminal prompt (store to keyring if available)
     """
-    log.info(pypirc_path)
+    log.debug("Loading repositories config from %r", pypirc_path)
     repos_cfg = get_repositories(pypirc_path)
-    log.info(repos_cfg)
 
     if name is not None:
         repo = repos_cfg[name]

--- a/flit/upload.py
+++ b/flit/upload.py
@@ -238,7 +238,7 @@ def upload_file(file:Path, metadata:Metadata, repo):
     resp.raise_for_status()
 
 
-def do_upload(file:Path, metadata:Metadata, pypirc_path:Path, repo_name=None):
+def do_upload(file:Path, metadata:Metadata, pypirc_path, repo_name=None):
     """Upload a file to an index server.
     """
     repo = get_repository(pypirc_path, repo_name)

--- a/flit/upload.py
+++ b/flit/upload.py
@@ -85,9 +85,9 @@ def get_repository(pypirc_path, name=None):
     3. keyring
     4. Terminal prompt (store to keyring if available)
     """
-    print(pypirc_path)
+    log.info(pypirc_path)
     repos_cfg = get_repositories(pypirc_path)
-    print(repos_cfg)
+    log.info(repos_cfg)
 
     if name is not None:
         repo = repos_cfg[name]

--- a/flit/upload.py
+++ b/flit/upload.py
@@ -115,7 +115,7 @@ def get_repository(pypirc_path, name=None):
         while not repo['username']:
             repo['username'] = input("Username: ")
         if repo['url'] == PYPI:
-            write_pypirc(repo)
+            write_pypirc(repo, pypirc_path)
     elif not repo['username']:
         raise Exception("Could not find username for upload.")
 

--- a/flit/upload.py
+++ b/flit/upload.py
@@ -254,7 +254,7 @@ def do_upload(file:Path, metadata:Metadata, pypirc_path="~/.pypirc", repo_name=N
         log.info("Package is at %s/%s", repo['url'], metadata.name)
 
 
-def main(ini_path, repo_name, pypirc_path, formats=None, gen_setup_py=True):
+def main(ini_path, repo_name, pypirc_path=None, formats=None, gen_setup_py=True):
     """Build and upload wheel and sdist."""
     if pypirc_path is None:
         pypirc_path = PYPIRC_DEFAULT

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,5 +1,4 @@
 from contextlib import contextmanager
-from flit.build import ALL_FORMATS
 import io
 import pathlib
 import sys
@@ -7,9 +6,9 @@ import sys
 import responses
 from testpath import modified_env
 from unittest.mock import patch
-from typing import Any
 
 from flit import upload
+from flit.build import ALL_FORMATS
 
 samples_dir = pathlib.Path(__file__).parent / 'samples'
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -155,3 +155,16 @@ def test_upload_invalid_pypirc_file(copy_sample):
                 repo_name="test123",
                 pypirc_path="./file.invalid",
             )
+
+def test_upload_default_pypirc_file(copy_sample):
+    with patch("flit.upload.do_upload") as do_upload:
+        td = copy_sample("module1_toml")
+        formats = list(ALL_FORMATS)[:1]
+        upload.main(
+            td / "pyproject.toml",
+            formats=set(formats),
+            repo_name="test123",
+        )
+
+        file = do_upload.call_args[0][2]
+        assert file == "~/.pypirc"


### PR DESCRIPTION
This PR adds support for handling a custom path for the `.pypirc` file. Previously the file was assumed to always be in `~/.pypirc`, which can be an issue depending on the build environment that is being used as stated in #426.

The path can be passed through the `--pypirc` argument, as such:
```sh
flit publish --pypirc .pypirc
```

A unit test was added to ensure the parsing is correctly done when the custom path is specified.

