### PR TITLE
Switch TOML library to tomli

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.5, 3.6, 3.7, 3.8, 3.9, ]
+        python-version: [ 3.6, 3.7, 3.8, 3.9, ]
     steps:
       - uses: actions/checkout@v2
 
@@ -23,27 +23,6 @@ jobs:
 
       - name: Run tests
         run: tox
-
-      - name: Codecov upload
-        run: codecov
-
-  # tox-gh-actions requires Python >= 3.5, so test 3.4 separately
-  test-py34:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup Python 3.4
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.4
-
-      - name: Install dependencies
-        run: |
-          pip install tox codecov
-
-      - name: Run tests
-        run: tox -e py34
 
       - name: Codecov upload
         run: codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   matrix:
     - TOXENV: "py37"
       TOX_APPVEYOR_X64: "1"
-    - TOXENV: "py35"
+    - TOXENV: "py36"
       TOX_APPVEYOR_X64: "0"
 
 # The Python version here doesn't matter (except that the commands have the same),

--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -333,7 +333,8 @@ Here's the full metadata section from flit itself:
         "flit_core>=2.2.0",
         "requests",
         "docutils",
-        "toml",
+        "tomli",
+        "tomli-w",
     ]
     requires-python=">=3.6"
     description-file="README.rst"

--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -334,9 +334,8 @@ Here's the full metadata section from flit itself:
         "requests",
         "docutils",
         "toml",
-        "zipfile36; python_version in '3.3 3.4 3.5'",
     ]
-    requires-python=">=3.5"
+    requires-python=">=3.6"
     description-file="README.rst"
     classifiers=[
         "Intended Audience :: Developers",

--- a/flit/init.py
+++ b/flit/init.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 import re
 import sys
-import toml
+import tomli_w
 
 def get_data_dir():
     """Get the directory path for flit user data files.
@@ -223,13 +223,14 @@ class TerminalIniter(IniterBase):
                 name=json.dumps(module), authors=authors_list
             ))
             if readme:
-                toml.dump({'readme': readme}, f)
+                f.write(tomli_w.dumps({'readme': readme}))
             if classifiers:
                 f.write(f"classifiers = {json.dumps(classifiers)}\n")
             f.write('dynamic = ["version", "description"]\n')
             if home_page:
-                f.write("\n")
-                toml.dump({'project': {'urls': {'Home': home_page}}}, f)
+                f.write("\n" + tomli_w.dumps({
+                    'project': {'urls': {'Home': home_page}}
+                }))
 
         print()
         print("Written pyproject.toml; edit that file to add optional extra info.")

--- a/flit/tomlify.py
+++ b/flit/tomlify.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 import configparser
 import os
 from pathlib import Path
-import toml
+import tomli_w
 
 from .config import metadata_list_fields
 
@@ -49,11 +49,11 @@ def convert(path):
 
     written_entrypoints = False
     with Path('pyproject.toml').open('w', encoding='utf-8') as f:
-        f.write(TEMPLATE.format(metadata=toml.dumps(metadata)))
+        f.write(TEMPLATE.format(metadata=tomli_w.dumps(metadata)))
 
         if scripts:
             f.write('\n[tool.flit.scripts]\n')
-            toml.dump(scripts, f)
+            f.write(tomli_w.dumps(scripts))
 
         for groupname, group in entrypoints.items():
             if not dict(group):
@@ -62,7 +62,7 @@ def convert(path):
             if '.' in groupname:
                 groupname = '"{}"'.format(groupname)
             f.write('\n[tool.flit.entrypoints.{}]\n'.format(groupname))
-            toml.dump(OrderedDict(group), f)
+            f.write(tomli_w.dumps(OrderedDict(group)))
             written_entrypoints = True
 
     print("Written 'pyproject.toml'")

--- a/flit_core/flit_core/build_thyself.py
+++ b/flit_core/flit_core/build_thyself.py
@@ -25,7 +25,7 @@ metadata_dict = {
     'summary': ('Distribution-building parts of Flit. '
                     'See flit package for more information'),
     'requires_dist': [
-        'toml',
+        'tomli',
     ],
     'requires_python': '>=3.6',
     'classifiers': [

--- a/flit_core/flit_core/build_thyself.py
+++ b/flit_core/flit_core/build_thyself.py
@@ -27,7 +27,7 @@ metadata_dict = {
     'requires_dist': [
         'toml',
     ],
-    'requires_python': '>=3.4',
+    'requires_python': '>=3.6',
     'classifiers': [
         "License :: OSI Approved :: BSD License",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -5,7 +5,7 @@ import logging
 import os
 import os.path as osp
 from pathlib import Path
-import toml
+import tomli
 import re
 
 from .versionno import normalise_version
@@ -66,8 +66,7 @@ pep621_allowed_fields = {
 def read_flit_config(path):
     """Read and check the `pyproject.toml` file with data about the package.
     """
-    with path.open('r', encoding='utf-8') as f:
-        d = toml.load(f)
+    d = tomli.loads(path.read_text('utf-8'))
     return prep_toml_config(d, path)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "requests",
     "docutils",
     "toml",
-    "zipfile36; python_version == '3.5'",
 ]
 requires-python = ">=3.6"
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     "flit_core >=3.3.0",
     "requests",
     "docutils",
-    "toml",
+    "tomli",
+    "tomli-w",
 ]
 requires-python = ">=3.6"
 readme = "README.rst"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,7 +6,7 @@ from testpath import assert_isfile
 from unittest.mock import patch
 import pytest
 
-import toml
+import tomli
 
 from flit import init
 
@@ -106,8 +106,8 @@ def test_init():
 
         generated = Path(td) / 'pyproject.toml'
         assert_isfile(generated)
-        with generated.open() as f:
-            data = toml.load(f)
+        with generated.open('rb') as f:
+            data = tomli.load(f)
         assert data['project']['authors'][0]['email'] == "test@example.com"
         license = Path(td) / 'LICENSE'
         assert_isfile(license)
@@ -129,8 +129,8 @@ def test_init_homepage_and_license_are_optional():
           faking_input(responses):
         ti = init.TerminalIniter(td)
         ti.initialise()
-        with Path(td, 'pyproject.toml').open() as f:
-            data = toml.load(f)
+        with Path(td, 'pyproject.toml').open('rb') as f:
+            data = tomli.load(f)
         assert not Path(td, 'LICENSE').exists()
     assert data['project'] == {
         'authors': [{'name': 'Test Author', 'email': 'test_email@example.com'}],
@@ -151,8 +151,8 @@ def test_init_homepage_validator():
           faking_input(responses):
         ti = init.TerminalIniter(td)
         ti.initialise()
-        with Path(td, 'pyproject.toml').open() as f:
-            data = toml.load(f)
+        with Path(td, 'pyproject.toml').open('rb') as f:
+            data = tomli.load(f)
     assert data['project'] == {
         'authors': [{'name': 'Test Author', 'email': 'test_email@example.com'}],
         'name': 'test_module_name',
@@ -172,8 +172,8 @@ def test_author_email_field_is_optional():
           faking_input(responses):
         ti = init.TerminalIniter(td)
         ti.initialise()
-        with Path(td, 'pyproject.toml').open() as f:
-            data = toml.load(f)
+        with Path(td, 'pyproject.toml').open('rb') as f:
+            data = tomli.load(f)
         assert not Path(td, 'LICENSE').exists()
 
     assert data['project'] == {
@@ -213,8 +213,8 @@ def test_init_readme_found_yes_choosen():
           faking_input(responses):
         ti = init.TerminalIniter(td)
         ti.initialise()
-        with Path(td, 'pyproject.toml').open() as f:
-            data = toml.load(f)
+        with Path(td, 'pyproject.toml').open('rb') as f:
+            data = tomli.load(f)
 
     assert data['project'] == {
         'authors': [{'name': 'Test Author', 'email': 'test_email@example.com'}],

--- a/tests/test_tomlify.py
+++ b/tests/test_tomlify.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-import toml
+import tomli
 from shutil import copy
 from testpath import assert_isfile
 
@@ -17,8 +17,8 @@ def test_tomlify(copy_sample, monkeypatch):
     pyproject_toml = (td / 'pyproject.toml')
     assert_isfile(pyproject_toml)
 
-    with pyproject_toml.open(encoding='utf-8') as f:
-        content = toml.load(f)
+    with pyproject_toml.open('rb') as f:
+        content = tomli.load(f)
 
     assert 'build-system' in content
     assert 'tool' in content

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
-envlist = py{39,38,37,36,35,34},bootstrap
+envlist = py{39,38,37,36},bootstrap
 skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.4: py34
-    3.5: py35
     3.6: py36
     3.7: py37
     3.8: py38, bootstrap
@@ -22,12 +20,6 @@ deps =
     pytest>=2.7.3
     pytest-cov
 
-    py35: zipfile36
-    py34: zipfile36
-
-    # pytest requires attrs, and it now gets a version for Py >= 3.5 by default
-    py34: attrs <21
-
 skip_install=true
 
 setenv =
@@ -35,15 +27,6 @@ setenv =
 
 commands =
     python -m pytest --cov=flit --cov=flit_core/flit_core
-
-# Python 3.4 & 3.5: only test flit_core
-[testenv:py34]
-commands =
-    python -m pytest --cov=flit_core/flit_core --pyargs flit_core
-
-[testenv:py35]
-commands =
-    python -m pytest --cov=flit_core/flit_core --pyargs flit_core
 
 [testenv:bootstrap]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,8 @@ deps =
     testpath
     responses
     docutils
-    toml
+    tomli
+    tomli-w
     pytest>=2.7.3
     pytest-cov
 


### PR DESCRIPTION
tomli has rapidly become the de-facto standard. It's also compatible with some changes made for TOML version 1.0, which people are going to want to use.

This means the end of the line for Python 3.4 and 3.5 support in flit_core. Projects which still support those versions will need to ensure they can be built by flit_core version 3.3.0 (which means sticking to [TOML 0.5](https://toml.io/en/v0.5.0)). Both of those Python versions are already end-of-life in that they're not getting bugfix releases, so hopefully not many people are affected by this.