### PR TITLE
add test using git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,9 @@ Source = "https://github.com/takluyver/flit"
 
 [project.scripts]
 flit = "flit:main"
+
+[tool.pytest.ini_options]
+markers = [
+    "needgit: needs git to be installed in order to run",
+    "needsgit: needs git to be installed in order to run",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import shlex
 from pathlib import Path
 from shutil import copy, copytree, which
 from subprocess import check_output
@@ -39,7 +40,7 @@ def copy_sample(tmp_path):
 
 def git(repo: Path, command: "Union[List[str], str]") -> bytes:
     if isinstance(command, str):
-        args = command.split()
+        args = shlex.split(command)
     else:
         args = command
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def git(repo: Path, command: "Union[List[str], str]") -> bytes:
 
 
 @pytest.fixture
-def tmp_git(tmp_path: Path) -> "Iterator[Path]":
+def tmp_git_repo(tmp_path: Path) -> "Iterator[Path]":
     """
     Make a git repository in a temporary folder
 
@@ -88,11 +88,11 @@ def tmp_git(tmp_path: Path) -> "Iterator[Path]":
 
 
 @pytest.fixture
-def tmp_project(tmp_git: Path) -> "Iterator[Path]":
+def tmp_project(tmp_git_repo: Path) -> "Iterator[Path]":
     "return a path to the root of a git repository containing a sample package"
     for file in (samples_dir / "module1_toml").glob("*"):
-        copy(str(file), str(tmp_git / file.name))
-    git(tmp_git, "add -A :/")
-    git(tmp_git, "commit --allow-empty --allow-empty-message --no-edit")
+        copy(str(file), str(tmp_git_repo / file.name))
+    git(tmp_git_repo, "add -A :/")
+    git(tmp_git_repo, "commit --allow-empty --allow-empty-message --no-edit")
 
-    yield tmp_git
+    yield tmp_git_repo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,97 @@
 from pathlib import Path
-import pytest
-from shutil import copytree
+from shutil import copy, copytree, which
+from subprocess import check_output
+from typing import TYPE_CHECKING
+from unittest.mock import patch
 
-samples_dir = Path(__file__).parent / 'samples'
+import pytest
+
+if TYPE_CHECKING:
+    from typing import Iterator, List, Union
+
+samples_dir = Path(__file__).parent / "samples"
+
+skip_if_no_git = pytest.mark.skipif(
+    (not which("git")),
+    reason="needs git to be installed and findable through the PATH environment variable",
+)
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if "needgit" in item.nodeid or "needsgit" in item.nodeid:
+            item.add_marker(skip_if_no_git)
+            item.add_marker(pytest.mark.needgit)
+            item.add_marker(pytest.mark.needsgit)
+
 
 @pytest.fixture
 def copy_sample(tmp_path):
     """Copy a subdirectory from the samples dir to a temp dir"""
+
     def copy(dirname):
         dst = tmp_path / dirname
         copytree(str(samples_dir / dirname), str(dst))
         return dst
 
     return copy
+
+
+def git(repo: Path, command: "Union[List[str], str]") -> bytes:
+    if isinstance(command, str):
+        args = command.split()
+    else:
+        args = command
+
+    return check_output(
+        ["git", "-C", str(repo), *args],
+    )
+
+
+@pytest.fixture
+def tmp_git(tmp_path: Path) -> "Iterator[Path]":
+    """
+    Make a git repository in a temporary folder
+
+    The path returned is what should be passed to git's -C command, or what cwd
+    should be set to in subprocess calls
+    """
+    git_global_config = tmp_path / "git_global_config"
+    git_global_config.touch(exist_ok=False)
+    repository = tmp_path / "repository"
+    repository.mkdir(exist_ok=False)
+    with patch.dict(
+        "os.environ",
+        {
+            # https://git-scm.com/docs/git#Documentation/git.txt-codeGITCONFIGGLOBALcode
+            "GIT_CONFIG_GLOBAL": str(git_global_config),
+            # https://git-scm.com/docs/git#Documentation/git.txt-codeGITCONFIGNOSYSTEMcode
+            "GIT_CONFIG_NOSYSTEM": "true",
+            "HOME": str(tmp_path),
+            # tox by default only passes the PATH environment variable, so
+            # XDG_CONFIG_HOME is already unset
+            # https://github.com/git/git/blob/cefe983a320c03d7843ac78e73bd513a27806845/t/test-lib.sh#L454-L461
+            "GIT_AUTHOR_EMAIL": "author@example.com",
+            "GIT_AUTHOR_NAME": "A U Thor",
+            "GIT_AUTHOR_DATE": "1112354055 +0200",
+            "GIT_COMMITTER_EMAIL": "committer@example.com",
+            "GIT_COMMITTER_NAME": "committer",
+            "GIT_COMMITTER_DATE": "1112354055 +0200",
+        },
+    ):
+        git(repository, "config --global init.defaultBranch main")
+        git(repository, ["init"])
+        git(repository, "commit --allow-empty --allow-empty-message --no-edit")
+
+        yield repository
+
+
+@pytest.fixture
+def tmp_project(tmp_git: Path) -> "Iterator[Path]":
+    "return a path to the root of a git repository containing a sample package"
+    for file in (samples_dir / "module1_toml").glob("*"):
+        copy(str(file), str(tmp_git / file.name))
+    git(tmp_git, "add -A :/")
+    git(tmp_git, "commit --allow-empty --allow-empty-message --no-edit")
+
+    yield tmp_git

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,15 +3,9 @@ from functools import wraps
 from pathlib import Path
 from shutil import copy, copytree, which
 from subprocess import check_output
-from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
-
-if TYPE_CHECKING:
-    from typing import Callable, Iterator, List, Union
-
-    GitCmd = Callable[Union[str, List[str]], bytes]
 
 samples_dir = Path(__file__).parent / "samples"
 
@@ -41,7 +35,7 @@ def copy_sample(tmp_path):
     return copy
 
 
-def git_cmd(repository_path: Path, command: "Union[List[str], str]") -> bytes:
+def git_cmd(repository_path, command):
     if isinstance(command, str):
         args = shlex.split(command)
     else:
@@ -53,7 +47,7 @@ def git_cmd(repository_path: Path, command: "Union[List[str], str]") -> bytes:
 
 
 @pytest.fixture
-def tmp_git_repo(tmp_path: Path) -> "Iterator[Path]":
+def tmp_git_repo(tmp_path):
     """
     Make a git repository in a temporary folder
 
@@ -91,16 +85,16 @@ def tmp_git_repo(tmp_path: Path) -> "Iterator[Path]":
 
 
 @pytest.fixture
-def git(tmp_git_repo: Path) -> "Iterator[GitCmd]":
+def git(tmp_git_repo):
     @wraps(git_cmd)
-    def wrapper(command: "Union[str, List[str]]") -> bytes:
+    def wrapper(command):
         return git_cmd(repository_path=tmp_git_repo, command=command)
 
     return wrapper
 
 
 @pytest.fixture
-def tmp_project(tmp_git_repo: Path, git: "GitCmd") -> "Iterator[Path]":
+def tmp_project(tmp_git_repo, git):
     "return a path to the root of a git repository containing a sample package"
     for file in (samples_dir / "module1_toml").glob("*"):
         copy(str(file), str(tmp_git_repo / file.name))

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -5,6 +5,7 @@ import sys
 from tempfile import TemporaryDirectory
 from testpath import assert_isdir, MockCommand
 
+from .conftest import git
 from flit_core import common
 from flit import build
 
@@ -69,3 +70,11 @@ def test_build_module_no_docstring():
             with pytest.raises(common.NoDocstringError) as exc_info:
                 build.main(pyproject)
             assert 'no_docstring.py' in str(exc_info.value)
+
+def test_build_needgit_unicode_filenames(tmp_project: Path) -> None:
+    "does a package build if it includes a unicode filename?"
+    noel_file = tmp_project / "No\N{LATIN SMALL LETTER E WITH DIAERESIS}l"
+    noel_file.touch()
+    git(tmp_project, "add -A :/")
+    git(tmp_project, "commit --allow-empty --allow-empty-message --no-edit")
+    build.main(tmp_project / "pyproject.toml")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -70,7 +70,7 @@ def test_build_module_no_docstring():
                 build.main(pyproject)
             assert 'no_docstring.py' in str(exc_info.value)
 
-def test_build_needgit_unicode_filenames(tmp_project: Path, git: "GitCmd") -> None:
+def test_build_needgit_unicode_filenames(tmp_project, git):
     "does a package build if it includes a unicode filename?"
     noel_file = tmp_project / "No\N{LATIN SMALL LETTER E WITH DIAERESIS}l"
     noel_file.touch()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -5,7 +5,6 @@ import sys
 from tempfile import TemporaryDirectory
 from testpath import assert_isdir, MockCommand
 
-from .conftest import git
 from flit_core import common
 from flit import build
 
@@ -71,10 +70,10 @@ def test_build_module_no_docstring():
                 build.main(pyproject)
             assert 'no_docstring.py' in str(exc_info.value)
 
-def test_build_needgit_unicode_filenames(tmp_project: Path) -> None:
+def test_build_needgit_unicode_filenames(tmp_project: Path, git: "GitCmd") -> None:
     "does a package build if it includes a unicode filename?"
     noel_file = tmp_project / "No\N{LATIN SMALL LETTER E WITH DIAERESIS}l"
     noel_file.touch()
-    git(tmp_project, "add -A :/")
-    git(tmp_project, "commit --allow-empty --allow-empty-message --no-edit")
+    git("add -A :/")
+    git("commit --allow-empty --allow-empty-message --no-edit")
     build.main(tmp_project / "pyproject.toml")

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ setenv =
     PYTHONPATH = flit_core
 
 commands =
-    python -m pytest --cov=flit --cov=flit_core/flit_core
+    python -m pytest --cov=flit --cov=flit_core/flit_core {posargs}
 
 [testenv:bootstrap]
 skip_install = true


### PR DESCRIPTION
This adds a few pytest fixtures that set up a git repository using `git`.

I used [this stackoverflow answer](https://stackoverflow.com/a/43882168) to isolate git using these environment variable:

- `GIT_CONFIG_GLOBAL`
- `GIT_CONFIG_NOSYSTEM`
- `HOME`
- `GIT_AUTHOR_EMAIL`
- `GIT_AUTHOR_NAME`
- `GIT_AUTHOR_DATE`
- `GIT_COMMITTER_EMAIL`
- `GIT_COMMITTER_NAME`
- `GIT_COMMITTER_DATE`

Instead of using `GIT_DIR` and `GIT_WORK_TREE`, I added another fixture that forms a closure around git, and calls it's `-C` command-line option, pointing to the temporary repository.

I'm not familiar with testing git, so I'm not sure if these measures are sufficient.

The `tmp_git_repo` fixture initializes the temporary repository with an empty commit. This isn't strictly necessary, it just makes some of the possible tests require less setup.

The `tmp_project` fixture copies the sample module from [`./tests/samples/module1_toml`](https://github.com/takluyver/flit/tree/87162fdeefb0a8d34a22193bf7f6c28828563e1d/tests/samples/module1_toml) to the repository and commits the files.

A test is added for #345 as an example of how to use the new fixtures.

I wanted to be able to run `tox` and `pytest` targeting or excluding only the tests that depend on `git` being installed:

```sh
tox -- -m needgit
```

or skipped:

```sh
tox -- -m "not needgit"
```

I kept getting confused myself, so both `needgit` and `needsgit` work.

Currently this is selected based on the test function name including `needgit` or `needsgit`, and I can understand if that's a bit too magical.

The tests are skipped if `shutil.which("git")` returns nothing, though I did not test this.

---

## Possible changes

Would it make more sense to have `tmp_project` behave similarly to the existing `copy_sample` fixture?

It could take as an argument the sample module and return a [`contextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager)-wrapped iterator that copies the named sample module files into the git repository and commits the changes:

```python
def test_example(copy_to_repo):
    with copy_to_repo("module1_toml") as repo:
        ...
```