### PR TITLE
Implement implicit namespace packages

### DIFF
--- a/flit_core/flit_core/buildapi.py
+++ b/flit_core/flit_core/buildapi.py
@@ -28,8 +28,9 @@ def get_requires_for_build_wheel(config_settings=None):
     want_summary = 'description' in info.dynamic_metadata
     want_version = 'version' in info.dynamic_metadata
 
-    module = Module(info.module, Path.cwd())
-    docstring, version = get_docstring_and_version_via_ast(module)
+    if want_summary or want_version:
+        module = Module(info.module, Path.cwd())
+        docstring, version = get_docstring_and_version_via_ast(module)
 
     if (want_summary and not docstring) or (want_version and not version):
         return info.metadata.get('requires_dist', [])

--- a/flit_core/flit_core/sdist.py
+++ b/flit_core/flit_core/sdist.py
@@ -138,9 +138,11 @@ class SdistBuilder:
                     osp.relpath(osp.join(dirpath, d), cfgdir_s)
                 )]
 
-        crucial_files = set(
-            self.extra_files + [str(self.module.file.relative_to(self.cfgdir))]
-        )
+        crucial_files = set(self.extra_files)
+        if self.module.file.is_file():
+            # If the module file does not exist, we are building a namespace package where
+            # the module file is by definition not crucial
+            crucial_files.add(str(self.module.file.relative_to(self.cfgdir)))
         missing_crucial = crucial_files - files
         if missing_crucial:
             raise Exception("Crucial files were excluded from the sdist: {}"

--- a/flit_core/flit_core/tests/samples/namespace_package/README.rst
+++ b/flit_core/flit_core/tests/samples/namespace_package/README.rst
@@ -1,0 +1,1 @@
+Some readme

--- a/flit_core/flit_core/tests/samples/namespace_package/pyproject.toml
+++ b/flit_core/flit_core/tests/samples/namespace_package/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "module1"
+version = "0.03"
+description = "Statically specified description"
+authors = [
+    {name = "Sir Robin", email = "robin@camelot.uk"}
+]
+readme = {file = "README.rst", content-type = "text/x-rst"}
+classifiers = [
+    "Topic :: Internet :: WWW/HTTP",
+]
+dependencies = []
+
+[project.urls]
+homepage = "http://github.com/sirrobin/module1"
+
+[project.scripts]
+foo = "module1.submodule:main"
+
+[project.gui-scripts]
+foo-gui = "module1.submodule:main"

--- a/flit_core/flit_core/tests/test_sdist.py
+++ b/flit_core/flit_core/tests/test_sdist.py
@@ -31,6 +31,15 @@ def test_make_sdist_pep621_nodynamic(tmp_path):
     assert_isfile(path)
 
 
+def test_make_sdist_namespace_package(tmp_path):
+    builder = sdist.SdistBuilder.from_ini_path(
+        samples_dir / 'namespace_package' / 'pyproject.toml'
+    )
+    path = builder.build(tmp_path)
+    assert path == tmp_path / 'module1-0.3.tar.gz'
+    assert_isfile(path)
+
+
 def test_clean_tarinfo():
     with tarfile.open(mode='w', fileobj=BytesIO()) as tf:
         ti = tf.gettarinfo(str(samples_dir / 'module1.py'))


### PR DESCRIPTION
Since the implementation of PEP621 in flit, we can get namespace packages basically for free. The only required change is not reading or importing the module, when the information (description and version) has already been provided in `pyproject.toml`. This is accomplished with just one `if`. The other places already avoid reading the file when `project.dynamic` is empty in `pyproject.toml`. During `sdist` we also have to just not check for the module file.

Best,
Marten