### PR TITLE
Don't generate setup.py by default.

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -168,12 +168,14 @@ def main(argv=None):
 
     def gen_setup_py():
         if not (args.setup_py or args.no_setup_py):
-            log.info("Adding generated setup.py to sdist by default.")
+            log.info("Not generating setup.py in sdist (default changed)")
             log.info(
-                "This will change in a future version. Pass --[no-]setup-py to "
-                "control it."
+                "Recent versions of pip no longer need this generated file"
             )
-            return True
+            log.info(
+                "Use --[no-]setup-py to suppress this message or add setup.py"
+            )
+            return False
         return args.setup_py
 
     if args.subcmd == 'build':


### PR DESCRIPTION
Autogenerating `setup.py` was a workaround to let pip install from source before PEP 517. pip supports PEP 517 since 19.0 (January 2019). Of course it supports installing wheels since much earlier (2013), and this is the default installation method. So I'm gradually moving towards getting rid of the generated `setup.py` file.

In Flit 3.4 (2021-10-10), I added a message saying that the default would change, and adding a (no-op) `--setup-py` option.  This PR will make `--no-setup-py` the default behaviour, and update the message accordingly.

I haven't decided when to merge this yet. The `flit` command line tool is meant as a developer tool, so I think it's reasonable to do changes like this relatively quickly (unlike in the lower-level `flit_core` package). But the purpose of adding the message in 3.4 is to give people a chance to be aware of the change coming and react to it.