### PR TITLE
Update README.rst for flit_core >=3.2 metadata

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ or as a directory — and you want to distribute it.
 
        """An amazing sample package!"""
 
-       __version__ = '0.1'
+       __version__ = "0.1"
 
 2. Install flit if you don't already have it::
 
@@ -42,14 +42,16 @@ or as a directory — and you want to distribute it.
    .. code-block:: ini
 
        [build-system]
-       requires = ["flit_core >=2,<4"]
+       requires = ["flit_core >=3.2,<4"]
        build-backend = "flit_core.buildapi"
 
-       [tool.flit.metadata]
-       module = "foobar"
-       author = "Sir Robin"
-       author-email = "robin@camelot.uk"
-       home-page = "https://github.com/sirrobin/foobar"
+       [project]
+       name = "foobar"
+       authors = [{name = "Sir Robin", email = "robin@camelot.uk"}]
+       dynamic = ["version", "description"]
+
+       [project.urls]
+       Home = "https://github.com/sirrobin/foobar"
 
    You can edit this file to add other metadata, for example to set up
    command line scripts. See the

--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -63,7 +63,7 @@ A simple ``[project]`` table might look like this:
         "License :: OSI Approved :: MIT License",
     ]
     requires-python = ">=3.5"
-    dynamic = ['version', 'description']
+    dynamic = ["version", "description"]
 
 The allowed fields are:
 
@@ -324,7 +324,7 @@ license
 maintainer, maintainer-email
   Like author, for if you've taken over a project from someone else.
 
-Here's the full metadata section from flit itself:
+Here was the metadata section from flit using the older style:
 
 .. code-block:: toml
 
@@ -334,7 +334,7 @@ Here's the full metadata section from flit itself:
     author-email="thomas@kluyver.me.uk"
     home-page="https://github.com/takluyver/flit"
     requires=[
-        "flit_core>=2.2.0",
+        "flit_core >=2.2.0",
         "requests",
         "docutils",
         "tomli",


### PR DESCRIPTION
This PR updates README.rst to reflect the new project metadata format generated with `flit init`.

A few other rephrasing and minor whitespace and quote modifications here too.