### PR TITLE
Require newer Sphinx for building docs on RTD

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
-sphinxcontrib_github_alt
-sphinx-rtd-theme
+sphinx ~= 4.2
+sphinxcontrib_github_alt ~= 1.0
+sphinx-rtd-theme ~= 1.2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
 sphinx ~= 4.2
-sphinxcontrib_github_alt ~= 1.0
-sphinx-rtd-theme ~= 1.2
+sphinxcontrib_github_alt ~= 1.2
+sphinx-rtd-theme ~= 1.0


### PR DESCRIPTION
Should fix failing build.