### PR TITLE
Drop Python 3.6 and 3.7 support in flit-core

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,35 +51,9 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: codecov
 
-  test-py37:
-    runs-on: "ubuntu-22.04"
-    strategy:
-      matrix:
-        python-version: [ "3.7", ]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install tox tox-gh-actions codecov
-
-      - name: Run tests
-        run: tox
-
-      - name: Codecov upload
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: codecov
-
   packages:
     runs-on: ubuntu-latest
-    needs: [test, test-py37]
+    needs: [test]
     permissions:
       id-token: write  # OIDC for uploading to PyPI
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,36 +77,9 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: codecov
 
-  test-py36:
-    runs-on: "ubuntu-20.04"
-    strategy:
-      matrix:
-        python-version: [ "3.6", ]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install tox tox-gh-actions codecov
-
-      - name: Run tests
-        run: tox
-
-      - name: Codecov upload
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: codecov
-
-
   packages:
     runs-on: ubuntu-latest
-    needs: [test, test-py36]
+    needs: [test, test-py37]
     permissions:
       id-token: write  # OIDC for uploading to PyPI
 

--- a/flit_core/flit_core/buildapi.py
+++ b/flit_core/flit_core/buildapi.py
@@ -1,6 +1,5 @@
 """PEP-517 compliant buildsystem API"""
 import logging
-import io
 import os
 import os.path as osp
 from pathlib import Path
@@ -52,14 +51,14 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
                          dist_info_name(metadata.name, metadata.version))
     os.mkdir(dist_info)
 
-    with io.open(osp.join(dist_info, 'WHEEL'), 'w', encoding='utf-8') as f:
+    with open(osp.join(dist_info, 'WHEEL'), 'w', encoding='utf-8') as f:
         _write_wheel_file(f, supports_py2=metadata.supports_py2)
 
-    with io.open(osp.join(dist_info, 'METADATA'), 'w', encoding='utf-8') as f:
+    with open(osp.join(dist_info, 'METADATA'), 'w', encoding='utf-8') as f:
         metadata.write_metadata_file(f)
 
     if ini_info.entrypoints:
-        with io.open(osp.join(dist_info, 'entry_points.txt'), 'w', encoding='utf-8') as f:
+        with open(osp.join(dist_info, 'entry_points.txt'), 'w', encoding='utf-8') as f:
             write_entry_points(ini_info.entrypoints, f)
 
     return osp.basename(dist_info)

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 from .versionno import normalise_version
 
-class Module(object):
+class Module:
     """This represents the module/package that we are going to distribute
     """
     in_namespace_package = False
@@ -326,7 +326,7 @@ def normalize_file_permissions(st_mode):
         new_mode |= 0o111  # Executable: 644 -> 755
     return new_mode
 
-class Metadata(object):
+class Metadata:
 
     summary = None
     home_page = None

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -301,12 +301,12 @@ def write_entry_points(d, fp):
     Sorts on keys to ensure results are reproducible.
     """
     for group_name in sorted(d):
-        fp.write(u'[{}]\n'.format(group_name))
+        fp.write('[{}]\n'.format(group_name))
         group = d[group_name]
         for name in sorted(group):
             val = group[name]
-            fp.write(u'{}={}\n'.format(name, val))
-        fp.write(u'\n')
+            fp.write('{}={}\n'.format(name, val))
+        fp.write('\n')
 
 def hash_file(path, algorithm='sha256'):
     with open(path, 'rb') as f:
@@ -410,7 +410,7 @@ class Metadata(object):
 
         for field in fields:
             value = getattr(self, self._normalise_field_name(field))
-            fp.write(u"{}: {}\n".format(field, value))
+            fp.write("{}: {}\n".format(field, value))
 
         for field in optional_fields:
             value = getattr(self, self._normalise_field_name(field))
@@ -420,35 +420,35 @@ class Metadata(object):
                 # License (& Description, but we put that in the body)
                 # Indent following lines with 8 spaces:
                 value = '\n        '.join(value.splitlines())
-                fp.write(u"{}: {}\n".format(field, value))
+                fp.write("{}: {}\n".format(field, value))
 
 
         license_expr = getattr(self, self._normalise_field_name("License-Expression"))
         license = getattr(self, self._normalise_field_name("License"))
         if license_expr:
-            fp.write(u'License-Expression: {}\n'.format(license_expr))
+            fp.write('License-Expression: {}\n'.format(license_expr))
         elif license:  # Deprecated, superseded by License-Expression
-            fp.write(u'License: {}\n'.format(license))
+            fp.write('License: {}\n'.format(license))
 
         for clsfr in self.classifiers:
-            fp.write(u'Classifier: {}\n'.format(clsfr))
+            fp.write('Classifier: {}\n'.format(clsfr))
 
         for file in self.license_files:
-            fp.write(u'License-File: {}\n'.format(file))
+            fp.write('License-File: {}\n'.format(file))
 
         for req in self.requires_dist:
             normalised_req = self._normalise_requires_dist(req)
-            fp.write(u'Requires-Dist: {}\n'.format(normalised_req))
+            fp.write('Requires-Dist: {}\n'.format(normalised_req))
 
         for url in self.project_urls:
-            fp.write(u'Project-URL: {}\n'.format(url))
+            fp.write('Project-URL: {}\n'.format(url))
 
         for extra in self.provides_extra:
             normalised_extra = normalise_core_metadata_name(extra)
-            fp.write(u'Provides-Extra: {}\n'.format(normalised_extra))
+            fp.write('Provides-Extra: {}\n'.format(normalised_extra))
 
         if self.description is not None:
-            fp.write(u'\n' + self.description + u'\n')
+            fp.write('\n' + self.description + '\n')
 
     @property
     def supports_py2(self):

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -147,10 +147,7 @@ def get_docstring_and_version_via_ast(target):
             node = ast.parse(f.read())
         for child in node.body:
             if is_version_str_assignment(child):
-                if sys.version_info >= (3, 8):
-                    version = child.value.value
-                else:
-                    version = child.value.s
+                version = child.value.value
                 break
     return ast.get_docstring(node), version
 
@@ -159,8 +156,7 @@ def is_version_str_assignment(node):
     """Check if *node* is a simple string assignment to __version__"""
     if not isinstance(node, (ast.Assign, ast.AnnAssign)):
         return False
-    constant_type = ast.Constant if sys.version_info >= (3, 8) else ast.Str
-    if not isinstance(node.value, constant_type):
+    if not isinstance(node.value, ast.Constant):
         return False
     targets = (node.target,) if isinstance(node, ast.AnnAssign) else node.targets
     for target in targets:

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -94,9 +94,7 @@ class Module:
         """
         def _include(path):
             name = os.path.basename(path)
-            if (name == '__pycache__') or name.endswith('.pyc'):
-                return False
-            return True
+            return name != '__pycache__' and not name.endswith('.pyc')
 
         if self.is_package:
             # Ensure we sort all files and directories so the order is stable

--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -204,8 +204,7 @@ def flatten_entrypoints(ep):
         d1 = {}
         for k, v in d.items():
             if isinstance(v, dict):
-                for flattened in _flatten(v, prefix+'.'+k):
-                    yield flattened
+                yield from _flatten(v, f'{prefix}.{k}')
             else:
                 d1[k] = v
 

--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -252,7 +252,7 @@ def _check_glob_patterns(pats, clude):
     return normed
 
 
-class LoadedConfig(object):
+class LoadedConfig:
     def __init__(self):
         self.module = None
         self.metadata = {}

--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -286,7 +286,7 @@ def description_from_file(rel_path: str, proj_dir: Path, guess_mimetype=True):
     try:
         with desc_path.open('r', encoding='utf-8') as f:
             raw_desc = f.read()
-    except IOError as e:
+    except OSError as e:
         if e.errno == errno.ENOENT:
             raise ConfigError(
                 "Description file {} does not exist".format(desc_path)

--- a/flit_core/flit_core/wheel.py
+++ b/flit_core/flit_core/wheel.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import argparse
 from base64 import urlsafe_b64encode
 import contextlib
@@ -11,7 +12,6 @@ import stat
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Optional
 import zipfile
 
 from flit_core import __version__
@@ -37,7 +37,7 @@ def _set_zinfo_mode(zinfo, mode):
     zinfo.external_attr = mode << 16
 
 
-def zip_timestamp_from_env() -> Optional[tuple]:
+def zip_timestamp_from_env() -> tuple[int, int, int, int, int, int] | None:
     """Prepare a timestamp from $SOURCE_DATE_EPOCH, if set"""
     try:
         # If SOURCE_DATE_EPOCH is set (e.g. by Debian), it's used for

--- a/flit_core/flit_core/wheel.py
+++ b/flit_core/flit_core/wheel.py
@@ -19,7 +19,7 @@ from . import common
 
 log = logging.getLogger(__name__)
 
-wheel_file_template = u"""\
+wheel_file_template = """\
 Wheel-Version: 1.0
 Generator: flit {version}
 Root-Is-Purelib: true
@@ -28,8 +28,8 @@ Root-Is-Purelib: true
 def _write_wheel_file(f, supports_py2=False):
     f.write(wheel_file_template)
     if supports_py2:
-        f.write(u"Tag: py2-none-any\n")
-    f.write(u"Tag: py3-none-any\n")
+        f.write("Tag: py2-none-any\n")
+    f.write("Tag: py3-none-any\n")
 
 
 def _set_zinfo_mode(zinfo, mode):
@@ -197,7 +197,7 @@ class WheelBuilder:
         # Write a record of the files in the wheel
         with self._write_to_zip(self.dist_info + '/RECORD') as f:
             for path, hash, size in self.records:
-                f.write(u'{},sha256={},{}\n'.format(path, hash, size))
+                f.write('{},sha256={},{}\n'.format(path, hash, size))
             # RECORD itself is recorded with no hash or size
             f.write(self.dist_info + '/RECORD,,\n')
 

--- a/flit_core/flit_core/wheel.py
+++ b/flit_core/flit_core/wheel.py
@@ -3,7 +3,7 @@ from base64 import urlsafe_b64encode
 import contextlib
 from datetime import datetime, timezone
 import hashlib
-import io
+from io import StringIO
 import logging
 import os
 import os.path as osp
@@ -139,7 +139,7 @@ class WheelBuilder:
 
     @contextlib.contextmanager
     def _write_to_zip(self, rel_path, mode=0o644):
-        sio = io.StringIO()
+        sio = StringIO()
         yield sio
 
         log.debug("Writing data to %s in zip file", rel_path)
@@ -218,7 +218,7 @@ def make_wheel_in(ini_path, wheel_directory, editable=False):
     # a temporary_file, and rename it afterwards.
     (fd, temp_path) = tempfile.mkstemp(suffix='.whl', dir=str(wheel_directory))
     try:
-        with io.open(fd, 'w+b') as fp:
+        with open(fd, 'w+b') as fp:
             wb = WheelBuilder.from_ini_path(ini_path, fp)
             wb.build(editable)
 

--- a/flit_core/pyproject.toml
+++ b/flit_core/pyproject.toml
@@ -10,7 +10,7 @@ authors=[
 ]
 description = "Distribution-building parts of Flit. See flit package for more information"
 dependencies = []
-requires-python = '>=3.7'
+requires-python = '>=3.8'
 readme = "README.rst"
 license = "BSD-3-Clause"
 license-files = ["LICENSE*", "flit_core/vendor/**/LICENSE*"]

--- a/flit_core/pyproject.toml
+++ b/flit_core/pyproject.toml
@@ -10,7 +10,7 @@ authors=[
 ]
 description = "Distribution-building parts of Flit. See flit package for more information"
 dependencies = []
-requires-python = '>=3.6'
+requires-python = '>=3.7'
 readme = "README.rst"
 license = "BSD-3-Clause"
 license-files = ["LICENSE*", "flit_core/vendor/**/LICENSE*"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py{314,313,312,311,310,39,38,37,36},bootstrap
+envlist = py{314,313,312,311,310,39,38,37},bootstrap
 skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38, bootstrap
     3.9: py39
@@ -32,11 +31,6 @@ setenv =
 
 commands =
     python -m pytest --cov=flit --cov=flit_core/flit_core {posargs}
-
-# Python 3.6: only test flit_core
-[testenv:py36]
-commands =
-    python -m pytest --cov=flit_core/flit_core flit_core {posargs}
 
 # Python 3.7: only test flit_core
 [testenv:py37]

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py{314,313,312,311,310,39,38,37},bootstrap
+envlist = py{314,313,312,311,310,39,38},bootstrap
 skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38, bootstrap
     3.9: py39
     3.10: py310
@@ -31,11 +30,6 @@ setenv =
 
 commands =
     python -m pytest --cov=flit --cov=flit_core/flit_core {posargs}
-
-# Python 3.7: only test flit_core
-[testenv:py37]
-commands =
-    python -m pytest --cov=flit_core/flit_core flit_core {posargs}
 
 [testenv:bootstrap]
 skip_install = true


### PR DESCRIPTION
Resolves #730.

Split into individual commits, feel free to push to this branch to drop any commits you don't want to take.

Supporting Python 3.8+ means that *flit* can use dataclasses, which might be nice, but I've stuck to small simplifications in this series.

A