### PR TITLE
Use f-strings

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -42,7 +42,7 @@ def find_python_executable(python: Optional[str] = None) -> str:
     # see https://github.com/pypa/flit/pull/300 and https://bugs.python.org/issue38905
     resolved_python = shutil.which(python)
     if resolved_python is None:
-        raise PythonNotFoundError("Unable to resolve Python executable {!r}".format(python))
+        raise PythonNotFoundError(f"Unable to resolve Python executable {python!r}")
     try:
         return subprocess.check_output(
             [resolved_python, "-c", "import sys; print(sys.executable)"],
@@ -50,9 +50,8 @@ def find_python_executable(python: Optional[str] = None) -> str:
         ).strip()
     except Exception as e:
         raise PythonNotFoundError(
-            "{} occurred trying to find the absolute filepath of Python executable {!r} ({!r})".format(
-                e.__class__.__name__, python, resolved_python
-            )
+            f"{e.__class__.__name__} occurred trying to find the absolute filepath "
+            f"of Python executable {python!r} ({resolved_python!r})"
         ) from e
 
 
@@ -175,7 +174,7 @@ def main(argv=None):
                  "'python3 -m flit.tomlify' to convert it to pyproject.toml")
 
     if args.subcmd not in {'init'} and not args.ini_file.is_file():
-        sys.exit('Config file {} does not exist'.format(args.ini_file))
+        sys.exit(f'Config file {args.ini_file} does not exist')
 
     enable_colourful_output(logging.DEBUG if args.debug else logging.INFO)
 

--- a/flit/build.py
+++ b/flit/build.py
@@ -31,7 +31,7 @@ def main(ini_file: Path, formats=None, gen_setup_py=True, use_vcs=True):
     if not formats:
         formats = ALL_FORMATS
     elif not formats.issubset(ALL_FORMATS):
-        raise ValueError("Unknown package formats: {}".format(formats - ALL_FORMATS))
+        raise ValueError(f"Unknown package formats: {formats - ALL_FORMATS}")
 
     sdist_info = wheel_info = None
     dist_dir = ini_file.parent / 'dist'
@@ -55,6 +55,6 @@ def main(ini_file: Path, formats=None, gen_setup_py=True, use_vcs=True):
         elif 'wheel' in formats:
             wheel_info = make_wheel_in(ini_file, dist_dir)
     except ConfigError as e:
-        sys.exit('Config error: {}'.format(e))
+        sys.exit(f'Config error: {e}')
 
     return SimpleNamespace(wheel=wheel_info, sdist=sdist_info)

--- a/flit/init.py
+++ b/flit/init.py
@@ -107,7 +107,7 @@ class IniterBase:
     def update_defaults(self, author, author_email, module, home_page, license):
         new_defaults = {'author': author, 'author_email': author_email,
                         'license': license}
-        name_chunk_pat = r'\b{}\b'.format(re.escape(module))
+        name_chunk_pat = rf'\b{re.escape(module)}\b'
         if re.search(name_chunk_pat, home_page):
             new_defaults['home_page_template'] = \
                 re.sub(name_chunk_pat, '{modulename}', home_page, flags=re.I)
@@ -136,7 +136,7 @@ class IniterBase:
 class TerminalIniter(IniterBase):
     def prompt_text(self, prompt, default, validator, retry_msg="Try again."):
         if default is not None:
-            p = "{} [{}]: ".format(prompt, default)
+            p = f"{prompt} [{default}]: "
         else:
             p = prompt + ': '
         while True:
@@ -153,14 +153,14 @@ class TerminalIniter(IniterBase):
 
         print(prompt)
         for i, (key, text) in enumerate(options, start=1):
-            print("{}. {}".format(i, text))
+            print(f"{i}. {text}")
             if key == default:
                 default_ix = i
 
         while True:
             p = "Enter 1-" + str(len(options))
             if default_ix is not None:
-                p += ' [{}]'.format(default_ix)
+                p += f' [{default_ix}]'
             response = input(p+': ')
             if (default_ix is not None) and response == '':
                 return default

--- a/flit/install.py
+++ b/flit/install.py
@@ -187,8 +187,7 @@ class Installer(object):
 
             if sys.platform == 'win32':
                 cmd_file = script_file.with_suffix('.cmd')
-                cmd = '@echo off\r\n"{python}" "%~dp0\\{script}" %*\r\n'.format(
-                            python=self.python, script=name)
+                cmd = f'@echo off\r\n"{self.python}" "%~dp0\\{name}" %*\r\n'
                 log.debug("Writing script wrapper to %s", cmd_file)
                 with cmd_file.open('w') as f:
                     f.write(cmd)

--- a/flit/log.py
+++ b/flit/log.py
@@ -88,8 +88,7 @@ class LogFormatter(logging.Formatter):
 
     def formatMessage(self, record):
         l = len(record.message)
-        right_text = '{initial}-{name}'.format(initial=record.levelname[0],
-                                               name=record.name)
+        right_text = f'{record.levelname[0]}-{record.name}'
         if l + len(right_text) < self.termwidth:
             space = ' ' * (self.termwidth - (l + len(right_text)))
         else:

--- a/flit/sdist.py
+++ b/flit/sdist.py
@@ -202,37 +202,37 @@ class SdistBuilder(SdistBuilderCore):
         before, extra = [], []
         if self.module.is_package:
             packages, package_data = auto_packages(self.module)
-            before.append("packages = \\\n%s\n" % pformat(sorted(packages)))
-            before.append("package_data = \\\n%s\n" % pformat(package_data))
+            before.append(f"packages = \\\n{pformat(sorted(packages))}\n")
+            before.append(f"package_data = \\\n{pformat(package_data)}\n")
             extra.append("packages=packages,")
             extra.append("package_data=package_data,")
         else:
-            extra.append("py_modules={!r},".format([self.module.name]))
+            extra.append(f"py_modules={[self.module.name]!r},")
             if self.module.in_namespace_package:
                 packages = list(namespace_packages(self.module))
-                before.append("packages = \\\n%s\n" % pformat(packages))
+                before.append(f"packages = \\\n{pformat(packages)}\n")
                 extra.append("packages=packages,")
 
         if self.module.prefix:
             package_dir = pformat({'': self.module.prefix})
-            before.append("package_dir = \\\n%s\n" % package_dir)
+            before.append(f"package_dir = \\\n{package_dir}\n")
             extra.append("package_dir=package_dir,")
 
         install_reqs, extra_reqs = convert_requires(self.reqs_by_extra)
         if install_reqs:
-            before.append("install_requires = \\\n%s\n" % pformat(install_reqs))
+            before.append(f"install_requires = \\\n{pformat(install_reqs)}\n")
             extra.append("install_requires=install_requires,")
         if extra_reqs:
-            before.append("extras_require = \\\n%s\n" % pformat(extra_reqs))
+            before.append(f"extras_require = \\\n{pformat(extra_reqs)}\n")
             extra.append("extras_require=extras_require,")
 
         entrypoints = self.prep_entry_points()
         if entrypoints:
-            before.append("entry_points = \\\n%s\n" % pformat(entrypoints))
+            before.append(f"entry_points = \\\n{pformat(entrypoints)}\n")
             extra.append("entry_points=entry_points,")
 
         if self.metadata.requires_python:
-            extra.append('python_requires=%r,' % self.metadata.requires_python)
+            extra.append(f'python_requires={self.metadata.requires_python!r},')
 
         return SETUP.format(
             before='\n'.join(before),

--- a/flit/tomlify.py
+++ b/flit/tomlify.py
@@ -60,8 +60,8 @@ def convert(path):
                 continue
 
             if '.' in groupname:
-                groupname = '"{}"'.format(groupname)
-            f.write('\n[tool.flit.entrypoints.{}]\n'.format(groupname))
+                groupname = f'"{groupname}"'
+            f.write(f'\n[tool.flit.entrypoints.{groupname}]\n')
             f.write(tomli_w.dumps(OrderedDict(group)))
             written_entrypoints = True
 

--- a/flit/upload.py
+++ b/flit/upload.py
@@ -158,7 +158,7 @@ def write_pypirc(repo, file="~/.pypirc"):
 
     with open(file, 'w', encoding='utf-8') as f:
         f.write("[pypi]\n"
-                "username = %s\n" % repo.username)
+                f"username = {repo.username}\n")
 
 def get_password(repo: RepoDetails):
     try:

--- a/flit/validate.py
+++ b/flit/validate.py
@@ -84,7 +84,7 @@ def _download_and_cache_classifiers():
 def _verify_classifiers(classifiers, valid_classifiers):
     """Check classifiers against a set of known classifiers"""
     invalid = classifiers - valid_classifiers
-    return ["Unrecognised classifier: {!r}".format(c)
+    return [f"Unrecognised classifier: {c!r}"
             for c in sorted(invalid)]
 
 
@@ -152,8 +152,7 @@ def validate_entrypoints(entrypoints):
                 valid = _is_identifier_attr(v)
 
             if not valid:
-                problems.append('Invalid entry point in group {}: '
-                                '{} = {}'.format(groupname, k, v))
+                problems.append(f'Invalid entry point in group {groupname}: {k} = {v}')
     return problems
 
 # Distribution name, not quite the same as a Python identifier
@@ -171,7 +170,7 @@ def validate_name(metadata):
     name = metadata.get('name', None)
     if name is None or NAME.match(name):
         return []
-    return ['Invalid name: {!r}'.format(name)]
+    return [f'Invalid name: {name!r}']
 
 
 def _valid_version_specifier(s):
@@ -184,7 +183,7 @@ def validate_requires_python(metadata):
     spec = metadata.get('requires_python', None)
     if spec is None or _valid_version_specifier(spec):
         return []
-    return ['Invalid requires-python: {!r}'.format(spec)]
+    return [f'Invalid requires-python: {spec!r}']
 
 MARKER_VARS = {
     'python_version', 'python_full_version', 'os_name', 'sys_platform',
@@ -200,15 +199,15 @@ def validate_environment_marker(em):
         # TODO: validate parentheses properly. They're allowed by PEP 508.
         parts = MARKER_OP.split(c.strip('()'))
         if len(parts) != 3:
-            problems.append("Invalid expression in environment marker: {!r}".format(c))
+            problems.append(f"Invalid expression in environment marker: {c!r}")
             continue
         l, op, r = parts
         for var in (l.strip(), r.strip()):
             if var[:1] in {'"', "'"}:
                 if len(var) < 2 or var[-1:] != var[:1]:
-                    problems.append("Invalid string in environment marker: {}".format(var))
+                    problems.append(f"Invalid string in environment marker: {var}")
             elif var not in MARKER_VARS:
-                problems.append("Invalid variable name in environment marker: {!r}".format(var))
+                problems.append(f"Invalid variable name in environment marker: {var!r}")
     return problems
 
 def validate_requires_dist(metadata):
@@ -216,13 +215,13 @@ def validate_requires_dist(metadata):
     for req in metadata.get('requires_dist', []):
         m = REQUIREMENT.match(req)
         if not m:
-            probs.append("Could not parse requirement: {!r}".format(req))
+            probs.append(f"Could not parse requirement: {req!r}")
             continue
 
         extras, version, envmark = m.group('extras', 'version', 'envmark')
         if not (extras is None or all(NAME.match(e.strip())
                                       for e in extras[1:-1].split(','))):
-            probs.append("Invalid extras in requirement: {!r}".format(req))
+            probs.append(f"Invalid extras in requirement: {req!r}")
         if version is not None:
             if version.startswith('(') and version.endswith(')'):
                 version = version[1:-1]
@@ -230,8 +229,7 @@ def validate_requires_dist(metadata):
                 pass  # url specifier  TODO: validate URL
             elif not _valid_version_specifier(version):
                 print((extras, version, envmark))
-                probs.append("Invalid version specifier {!r} in requirement {!r}"
-                             .format(version, req))
+                probs.append(f"Invalid version specifier {version!r} in requirement {req!r}")
         if envmark is not None:
             probs.extend(validate_environment_marker(envmark[1:]))
     return probs
@@ -241,8 +239,7 @@ def validate_url(url):
         return []
     probs = []
     if not url.startswith(('http://', 'https://')):
-        probs.append("URL {!r} doesn't start with https:// or http://"
-                     .format(url))
+        probs.append(f"URL {url!r} doesn't start with https:// or http://")
     elif not url.split('//', 1)[1]:
         probs.append("URL missing address")
     return probs
@@ -253,10 +250,9 @@ def validate_project_urls(metadata):
         name, url = prurl.split(',', 1)
         url = url.lstrip()
         if not name:
-            probs.append("No name for project URL {!r}".format(url))
+            probs.append(f"No name for project URL {url!r}")
         elif len(name) > 32:
-            probs.append("Project URL name {!r} longer than 32 characters"
-                         .format(name))
+            probs.append(f"Project URL name {name!r} longer than 32 characters")
         probs.extend(validate_url(url))
 
     return probs

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -56,7 +56,7 @@ class Module:
                 .format(name, ", ".join([str(p) for p in sorted(existing)]))
             )
         elif not existing:
-            raise ValueError("No file/folder found for module {}".format(name))
+            raise ValueError(f"No file/folder found for module {name}")
 
         self.source_dir = directory / self.prefix
 
@@ -120,7 +120,7 @@ class VCSError(Exception):
         self.directory = directory
 
     def __str__(self):
-        return self.msg + ' ({})'.format(self.directory)
+        return f'{self.msg} ({self.directory})'
 
 
 @contextmanager
@@ -182,7 +182,7 @@ def get_docstring_and_version_via_import(target):
 
     log.debug("Loading module %s", target.file)
     from importlib.util import spec_from_file_location, module_from_spec
-    mod_name = 'flit_core.dummy.import%d' % _import_i
+    mod_name = f'flit_core.dummy.import{_import_i}'
     spec = spec_from_file_location(mod_name, target.file)
     with _module_load_ctx():
         m = module_from_spec(spec)
@@ -227,7 +227,7 @@ def get_info_from_module(target, for_fields=('version', 'description')):
         if (not docstring) or not docstring.strip():
             raise NoDocstringError(
                 'Flit cannot package module without docstring, or empty docstring. '
-                'Please add a docstring to your module ({}).'.format(target.file)
+                f'Please add a docstring to your module ({target.file}).'
             )
         res['summary'] = docstring.lstrip().splitlines()[0]
 
@@ -251,8 +251,7 @@ def check_version(version):
         raise NoVersionError('Cannot package module without a version string. '
                              'Please define a `__version__ = "x.y.z"` in your module.')
     if not isinstance(version, str):
-        raise InvalidVersion('__version__ must be a string, not {}.'
-                                .format(type(version)))
+        raise InvalidVersion(f'__version__ must be a string, not {type(version)}.')
 
     # Import here to avoid circular import
     version = normalise_version(version)
@@ -277,15 +276,15 @@ def parse_entry_point(ep):
     Returns (modulename, funcname)
     """
     if ':' not in ep:
-        raise ValueError("Invalid entry point (no ':'): %r" % ep)
+        raise ValueError(f"Invalid entry point (no ':'): {ep!r}")
     mod, func = ep.split(':')
 
     for piece in func.split('.'):
         if not piece.isidentifier():
-            raise ValueError("Invalid entry point: %r is not an identifier" % piece)
+            raise ValueError(f"Invalid entry point: {piece!r} is not an identifier")
     for piece in mod.split('.'):
         if not piece.isidentifier():
-            raise ValueError("Invalid entry point: %r is not a module path" % piece)
+            raise ValueError(f"Invalid entry point: {piece!r} is not a module path")
 
     return mod, func
 
@@ -295,11 +294,11 @@ def write_entry_points(d, fp):
     Sorts on keys to ensure results are reproducible.
     """
     for group_name in sorted(d):
-        fp.write('[{}]\n'.format(group_name))
+        fp.write(f'[{group_name}]\n')
         group = d[group_name]
         for name in sorted(group):
             val = group[name]
-            fp.write('{}={}\n'.format(name, val))
+            fp.write(f'{name}={val}\n')
         fp.write('\n')
 
 def hash_file(path, algorithm='sha256'):
@@ -359,7 +358,7 @@ class Metadata:
         self.version = data.pop('version')
 
         for k, v in data.items():
-            assert hasattr(self, k), "data does not have attribute '{}'".format(k)
+            assert hasattr(self, k), f"data does not have attribute '{k}'"
             setattr(self, k, v)
 
     def _normalise_field_name(self, n):
@@ -404,7 +403,7 @@ class Metadata:
 
         for field in fields:
             value = getattr(self, self._normalise_field_name(field))
-            fp.write("{}: {}\n".format(field, value))
+            fp.write(f"{field}: {value}\n")
 
         for field in optional_fields:
             value = getattr(self, self._normalise_field_name(field))
@@ -414,35 +413,35 @@ class Metadata:
                 # License (& Description, but we put that in the body)
                 # Indent following lines with 8 spaces:
                 value = '\n        '.join(value.splitlines())
-                fp.write("{}: {}\n".format(field, value))
+                fp.write(f"{field}: {value}\n")
 
 
         license_expr = getattr(self, self._normalise_field_name("License-Expression"))
         license = getattr(self, self._normalise_field_name("License"))
         if license_expr:
-            fp.write('License-Expression: {}\n'.format(license_expr))
+            fp.write(f'License-Expression: {license_expr}\n')
         elif license:  # Deprecated, superseded by License-Expression
-            fp.write('License: {}\n'.format(license))
+            fp.write(f'License: {license}\n')
 
         for clsfr in self.classifiers:
-            fp.write('Classifier: {}\n'.format(clsfr))
+            fp.write(f'Classifier: {clsfr}\n')
 
         for file in self.license_files:
-            fp.write('License-File: {}\n'.format(file))
+            fp.write(f'License-File: {file}\n')
 
         for req in self.requires_dist:
             normalised_req = self._normalise_requires_dist(req)
-            fp.write('Requires-Dist: {}\n'.format(normalised_req))
+            fp.write(f'Requires-Dist: {normalised_req}\n')
 
         for url in self.project_urls:
-            fp.write('Project-URL: {}\n'.format(url))
+            fp.write(f'Project-URL: {url}\n')
 
         for extra in self.provides_extra:
             normalised_extra = normalise_core_metadata_name(extra)
-            fp.write('Provides-Extra: {}\n'.format(normalised_extra))
+            fp.write(f'Provides-Extra: {normalised_extra}\n')
 
         if self.description is not None:
-            fp.write('\n' + self.description + '\n')
+            fp.write(f'\n{self.description}\n')
 
     @property
     def supports_py2(self):
@@ -476,12 +475,12 @@ def normalize_dist_name(name: str, version: str) -> str:
     normalized_name = re.sub(r'[-_.]+', '_', name, flags=re.UNICODE).lower()
     assert check_version(version) == version
     assert '-' not in version, 'Normalized versions can’t have dashes'
-    return '{}-{}'.format(normalized_name, version)
+    return f'{normalized_name}-{version}'
 
 
 def dist_info_name(distribution, version):
     """Get the correct name of the .dist-info folder"""
-    return normalize_dist_name(distribution, version) + '.dist-info'
+    return f'{normalize_dist_name(distribution, version)}.dist-info'
 
 
 def walk_data_dir(data_directory):

--- a/flit_core/flit_core/sdist.py
+++ b/flit_core/flit_core/sdist.py
@@ -103,7 +103,7 @@ class SdistBuilder:
         res = defaultdict(list)
         for groupname, group in self.entrypoints.items():
             for name, ep in sorted(group.items()):
-                res[groupname].append('{} = {}'.format(name, ep))
+                res[groupname].append(f'{name} = {ep}')
 
         return dict(res)
 
@@ -161,7 +161,7 @@ class SdistBuilder:
 
     def build(self, target_dir, gen_setup_py=True):
         os.makedirs(str(target_dir), exist_ok=True)
-        target = target_dir / '{}.tar.gz'.format(self.dir_name)
+        target = target_dir / f'{self.dir_name}.tar.gz'
         source_date_epoch = os.environ.get('SOURCE_DATE_EPOCH', '')
         mtime = int(source_date_epoch) if source_date_epoch else None
         # For the gzip timestamp, default to 2016-1-1 00:00 (UTC)

--- a/flit_core/flit_core/versionno.py
+++ b/flit_core/flit_core/versionno.py
@@ -78,20 +78,19 @@ def normalise_version(orig_version):
     m = VERSION_PERMISSIVE.match(version)
     if not m:
         if os.environ.get('FLIT_ALLOW_INVALID'):
-            log.warning("Invalid version number {!r} allowed by FLIT_ALLOW_INVALID"
-                        .format(orig_version))
+            log.warning("Invalid version number %r allowed by FLIT_ALLOW_INVALID",
+                        orig_version)
             return version
         else:
             from .common import InvalidVersion
-            raise InvalidVersion("Version number {!r} does not match PEP 440 rules"
-                                 .format(orig_version))
+            raise InvalidVersion(f"Version number {orig_version!r} does not match PEP 440 rules")
 
     components = []
     add = components.append
 
     epoch, release = m.group('epoch', 'release')
     if epoch is not None:
-        add(str(int(epoch)) + '!')
+        add(f'{int(epoch)}!')
     add('.'.join(str(int(rp)) for rp in release.split('.')))
 
     pre_l, pre_n = m.group('pre_l', 'pre_n')
@@ -121,6 +120,6 @@ def normalise_version(orig_version):
 
     version = ''.join(components)
     if version != orig_version:
-        log.warning("Version number normalised: {!r} -> {!r} (see PEP 440)"
-                    .format(orig_version, version))
+        log.warning("Version number normalised: %r -> %r (see PEP 440)",
+                    orig_version, version)
     return version


### PR DESCRIPTION
Beyond #738, this PR seeks to consistently adopt f-strings in both flit and flit-core. I realise this PR has a reasonably large diff, but I would argue that f-strings are both more readable and have better performance than either printf-style formatting or `str.format()` calls.

A