### PR TITLE
Default `license-files` glob: consistency between backends

### DIFF
--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -101,7 +101,7 @@ license
   ``text`` key (the license text).
 license-files
   A list of glob patterns for license files to include.
-  Defaults to ``['COPYING*', 'LICEN[CS]E*']``.
+  Defaults to ``['COPYING*', 'LICEN[CS]E*', 'NOTICE*', 'AUTHORS*']``.
 authors
   A list of tables with ``name`` and ``email`` keys (both optional) describing
   the authors of the project.

--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -74,7 +74,7 @@ pep621_allowed_fields = {
     'dynamic',
 }
 
-default_license_files_globs = ['COPYING*', 'LICEN[CS]E*']
+default_license_files_globs = ['COPYING*', 'LICEN[CS]E*', 'NOTICE*', 'AUTHORS*']
 license_files_allowed_chars = re.compile(r'^[\w\-\.\/\*\?\[\]]+$')
 
 


### PR DESCRIPTION
Fixes #757.

**Edit:** [Consistency with wheels](https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file) is probably a better argument than consistency with other backends.

> Several open source licenses require the license text to be included in every distributable artifact of the project. By default, `wheel` conveniently includes files matching the following [glob](https://docs.python.org/library/glob.html) patterns in the `.dist-info` directory:
> * `AUTHORS*`
> * `COPYING*`
> * `LICEN[CS]E*`
> * `NOTICE*`