### PR TITLE
[Docs] Use extension:filetype mapping in sphinx configuration

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,7 +35,7 @@ github_project_url = "https://github.com/pypa/flit"
 templates_path = ['_templates']
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = {".rst": "restructuredtext"}
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'


### PR DESCRIPTION
This is possible since sphinx 1.8, and avoid the message:
>  "Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`"

at docs build time. See https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-source_suffix