### PR TITLE
TST: add CPython 3.14 and 3.15 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
+          - "3.15"
     steps:
       - uses: actions/checkout@v5
 
@@ -37,6 +39,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
-          - "3.15"
     steps:
       - uses: actions/checkout@v5
 
@@ -39,7 +38,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
 
       - name: Install dependencies
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{314,313,312,311,310,39,38},bootstrap
+envlist = py{315,314,313,312,311,310,39,38},bootstrap
 skip_missing_interpreters = true
 
 [gh-actions]
@@ -11,6 +11,7 @@ python =
     3.12: py312
     3.13: py313
     3.14: py314
+    3.15: py315
 
 [testenv]
 deps =


### PR DESCRIPTION
3.14 is now stable so it shouldn't be controversial. I'm also thinking, given the position that `flit-core` has in the ecosystem, that testing against 3.15 early *could* potentially help catching impactful bugs sooner, rather than defering to dependees to discover issues at build time, but of course, that's just a proposal.