### PR TITLE
Remove flit.buildapi module

### DIFF
--- a/flit/buildapi.py
+++ b/flit/buildapi.py
@@ -1,6 +1,0 @@
-from warnings import warn
-warn('A package has specified `build-backend = "flit.buildapi"` and is being '
-     'built with Flit >= 3.10. This is likely to break in a future version. '
-     'Please change the backend to flit_core.buildapi, and/or specify a '
-     'maximum version of Flit.')
-from flit_core.buildapi import *


### PR DESCRIPTION
Packages should use `flit_core.buildapi` as the PEP 517 backend, instead of `flit.buildapi`.

I know there are packages out there still using `flit.buildapi`, which existed first. All the ones I've seen are also still using older-style metadata (`[tool.flit.metadata]` tables instead of `[project]`), so they won't build with Flit 4.0 anyway. If anyone finds an example with `[project]` metadata but `flit.buildapi` as the backend before Flit 4.0, I'll leave this module around to avoid needless breakage.

Closes #519.