### PR TITLE
Detect git worktrees and submodules in identify_vcs

### DIFF
--- a/flit/vcs/__init__.py
+++ b/flit/vcs/__init__.py
@@ -6,7 +6,11 @@ from . import git
 def identify_vcs(directory: Path):
     directory = directory.resolve()
     for p in [directory] + list(directory.parents):
-        if (p / '.git').is_dir():
+        # In a linked git worktree (`git worktree add ...`) or inside a
+        # git submodule, `.git` is a regular file containing a
+        # `gitdir: <path>` pointer rather than a directory.
+        git_entry = p / '.git'
+        if git_entry.is_dir() or git_entry.is_file():
             return git
         if (p / '.hg').is_dir():
             return hg

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -24,3 +24,14 @@ def test_identify_git_parent():
         subdir.mkdir()
         with cwd(subdir):
             assert vcs.identify_vcs(Path('.')).name == 'git'
+
+def test_identify_git_worktree():
+    # In a linked git worktree (or submodule) `.git` is a regular file
+    # containing a `gitdir:` pointer rather than a directory.
+    with TemporaryDirectory() as td:
+        td = Path(td)
+        (td / '.git').write_text('gitdir: /path/to/main/.git/worktrees/feature\n')
+        subdir = (td / 'subdir')
+        subdir.mkdir()
+        with cwd(subdir):
+            assert vcs.identify_vcs(Path('.')).name == 'git'


### PR DESCRIPTION
Closes #798.

## Problem

In a linked git worktree (`git worktree add ...`), or inside a git submodule, `.git` is a regular file containing a `gitdir: <path>` pointer rather than a directory. `flit/vcs/__init__.py:identify_vcs` only checked `.is_dir()`, so in these contexts it returns `None`, `flit/sdist.py:SdistBuilder.select_files` silently falls back to the non-VCS file set (`super().select_files()` from `flit_core`), and the resulting sdist omits tracked files such as `docs/`, `tests/`, and anything declared through `[tool.flit.sdist] include = [...]`. No warning is emitted.

## Change

Accept `.git` whether it is a directory or a file:

```python
git_entry = p / '.git'
if git_entry.is_dir() or git_entry.is_file():
    return git
```

Downstream `git ls-files` naturally validates the pointer target — no extra parsing needed inside `identify_vcs`.

## Test

Added `tests/test_vcs.py::test_identify_git_worktree`: create `.git` as a regular file containing a `gitdir:` pointer, `identify_vcs` now returns the `git` module. Existing `test_identify_git_parent` continues to cover the plain-checkout path.

Three other tests in `tests/test_sdist.py` and `tests/test_wheel.py` fail on current `main` in my environment — they also fail on `main` without this change, so they are unrelated and not regressed by this PR.

## Context

Discovered during Apache Airflow provider release verification — 20 sdists diverged byte-for-byte from the released tarballs because the release was built from a plain checkout while the verifier ran from a worktree (https://github.com/apache/airflow/pull/65771). The same failure shape surfaces when a worktree is bind-mounted into a container and the main repo's `.git` is not reachable.