### PR TITLE
Match dotfiles in sdist include/exclude glob patterns

### DIFF
--- a/doc/history.rst
+++ b/doc/history.rst
@@ -39,6 +39,9 @@ change the ``flit_core <4`` constraint to ``<5``.
   you did.
 - The vendorised ``readme_renderer`` package was updated to version 44.0
   (:ghpull:`760`).
+- Sdist ``include`` and ``exclude`` patterns now match files whose names start
+  with a dot, so e.g. ``exclude = ["**/*.swp"]`` correctly excludes editor
+  swap files like ``.foo.py.swp`` (:ghissue:`746`).
 
 
 Version 3.12

--- a/flit_core/flit_core/sdist.py
+++ b/flit_core/flit_core/sdist.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from copy import copy
-from glob import glob
 from gzip import GzipFile
 import io
 import logging
@@ -42,10 +41,14 @@ class FilePatterns:
         self.dirs = set()
         self.files = set()
 
+        basepath = Path(basedir)
         for pattern in patterns:
-            for path in sorted(glob(osp.join(basedir, pattern), recursive=True)):
-                rel = osp.relpath(path, basedir)
-                if osp.isdir(path):
+            # Use pathlib rather than the stdlib glob module: glob's wildcards
+            # skip files starting with a dot by default, so patterns like
+            # '**/*.swp' would fail to match e.g. '.foo.py.swp' (gh-746).
+            for path in sorted(basepath.glob(pattern)):
+                rel = osp.relpath(str(path), basedir)
+                if path.is_dir():
                     self.dirs.add(rel)
                 else:
                     self.files.add(rel)

--- a/flit_core/tests_core/samples/inclusion/pyproject.toml
+++ b/flit_core/tests_core/samples/inclusion/pyproject.toml
@@ -11,4 +11,4 @@ dynamic = ["version", "description"]
 
 [tool.flit.sdist]
 include = ["doc"]
-exclude = ["doc/*.txt", "doc/**/*.md"]
+exclude = ["doc/*.txt", "doc/**/*.md", "doc/**/*.swp"]

--- a/flit_core/tests_core/test_sdist.py
+++ b/flit_core/tests_core/test_sdist.py
@@ -50,6 +50,8 @@ def test_include_exclude():
     assert osp.join('doc', 'test.txt') not in files
     assert osp.join('doc', 'subdir', 'test.txt') in files
     assert osp.join('doc', 'subdir', 'subsubdir', 'test.md') not in files
+    # Recursive glob patterns should also match hidden (dot) files (gh-746)
+    assert osp.join('doc', 'subdir', '.hidden.swp') not in files
 
 
 def test_data_dir():


### PR DESCRIPTION
## Summary

Sdist `include` and `exclude` patterns were expanded using the stdlib `glob` module. `glob`'s wildcards do not match files whose names start with a dot, so a recursive pattern such as:

```toml
[tool.flit.sdist]
exclude = ["**/*.swp"]
```

failed to exclude editor swap files like `.foo.py.swp` from the sdist, even though the docs advertise recursive `**` support. As reported in #746, an explicit full path to a dotfile did exclude it, but a `**` glob pattern did not, because `glob` skips dotfiles by default.

## Fix

`flit_core/flit_core/sdist.py` now expands the patterns with `pathlib.Path.glob` instead of `glob.glob(..., recursive=True)`. `Path.glob` matches dotfiles by default and preserves the same recursive `**` semantics (including matching entries in the base directory). This deliberately avoids `glob`'s `include_hidden` keyword, which is only available on Python 3.11+, so the fix works on `flit_core`'s minimum supported Python (3.8).

## Tests / Verification

- Extended the `inclusion` sample fixture with a hidden file `doc/subdir/.hidden.swp` and an `exclude` entry `doc/**/*.swp`, and added an assertion to `test_include_exclude` that the dotfile is excluded.
- Confirmed the new assertion **fails** on the unpatched code (the dotfile was still included) and **passes** after the fix.
- Ran the full `flit_core` test suite (`flit_core/tests_core/`) plus the top-level `tests/test_sdist.py`: all green (218 passed, 1 pre-existing skip).
- Added a `doc/history.rst` entry.

Disclosure: prepared with AI assistance; reviewed and verified locally.
