### PR TITLE
docs: Fix missing comma after introductory adverb in pyproject_toml g…

### DIFF
--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -10,7 +10,7 @@ This file lives next to the module or package.
     table described below.
 
     If you need to build a package that used ``[tool.flit.metadata]``, you will
-    need ``flit_core <4``. Hopefully most packages specify this constraint and
+    need ``flit_core <4``. Hopefully, most packages specify this constraint and
     will automatically be built with the right version.
 
 Build system section


### PR DESCRIPTION
Fixes a missing comma after the introductory adverb ("Hopefully, most packages...") in the pyproject.toml configuration guide.