### PR TITLE
Prepare 4.0.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.0.0
+current_version = 4.0.1
 commit = True
 tag = False
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -52,7 +52,7 @@ copyright = '2015, Thomas Kluyver'
 # built documents.
 #
 # The short X.Y version.
-version = '4.0.0'
+version = '4.0.1'
 # The full version, including alpha/beta/rc tags.
 release = version #+ '.1'
 

--- a/doc/history.rst
+++ b/doc/history.rst
@@ -1,6 +1,12 @@
 Release history
 ===============
 
+Version 4.0.1
+-------------
+
+No changes, but a new tag to trigger an upload to PyPI now that twine will
+accept it.
+
 Version 4.0
 -----------
 

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -12,7 +12,7 @@ from flit_core import common
 from .config import ConfigError
 from .log import enable_colourful_output
 
-__version__ = '4.0.0'
+__version__ = '4.0.1'
 
 log = logging.getLogger(__name__)
 

--- a/flit_core/flit_core/__init__.py
+++ b/flit_core/flit_core/__init__.py
@@ -4,4 +4,4 @@ This package provides a standard PEP 517 API to build packages using Flit.
 All the convenient development features live in the main 'flit' package.
 """
 
-__version__ = '4.0.0'
+__version__ = '4.0.1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Thomas Kluyver", email = "thomas@kluyver.me.uk"},
 ]
 dependencies = [
-    "flit_core >=4.0.0",
+    "flit_core >=4.0.1",
     "requests",
     "docutils",
     "tomli-w",


### PR DESCRIPTION
There are no actual changes in the code from 4.0.0, but now twine can handle uploads with metadata v2.5.