### PR TITLE
Write Import-Name and Import-Namespace with a trailing newline

### DIFF
--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -444,10 +444,10 @@ class Metadata:
             fp.write(f'Provides-Extra: {normalised_extra}\n')
 
         for name in self.import_name:
-            fp.write(f'Import-Name: {name}')
+            fp.write(f'Import-Name: {name}\n')
 
         for name in self.import_namespace:
-            fp.write(f'Import-Namespace: {name}')
+            fp.write(f'Import-Namespace: {name}\n')
 
         if self.description is not None:
             fp.write(f'\n{self.description}\n')

--- a/flit_core/tests_core/test_common.py
+++ b/flit_core/tests_core/test_common.py
@@ -162,6 +162,25 @@ def test_metadata_multiline(tmp_path):
     assert [l.lstrip() for l in msg['Author'].splitlines()] == d['author'].splitlines()
     assert not msg.defects
 
+def test_metadata_import_names_before_description():
+    d = {
+        'name': 'foo',
+        'version': '1.0',
+        'import_name': ['a.b.c'],
+        'import_namespace': ['a', 'a.b'],
+        'description': 'Description body',
+    }
+    md = Metadata(d)
+    sio = StringIO()
+    md.write_metadata_file(sio)
+    sio.seek(0)
+
+    msg = email.parser.Parser(policy=email.policy.compat32).parse(sio)
+    assert msg.get_all('Import-Name') == d['import_name']
+    assert msg.get_all('Import-Namespace') == d['import_namespace']
+    assert msg.get_payload() == d['description'] + '\n'
+    assert not msg.defects
+
 @pytest.mark.parametrize(
     ("requires_dist", "expected_result"),
     [


### PR DESCRIPTION
`Import-Name` and `Import-Namespace` are the only fields `write_metadata_file` emits without terminating the line. The `\n` written ahead of the description is meant to be the blank separator between headers and body, but it ends up terminating the last `Import-*` line instead, so the description is parsed as part of the header block.

`flit_core` 4.0.1's own wheel on PyPI shows it:

```python
import email.parser, io, json, urllib.request, zipfile

d = json.load(urllib.request.urlopen("https://pypi.org/pypi/flit_core/4.0.1/json"))
url = [u["url"] for u in d["urls"] if u["url"].endswith(".whl")][0]
z = zipfile.ZipFile(io.BytesIO(urllib.request.urlopen(url).read()))
raw = z.read("flit_core-4.0.1.dist-info/METADATA")

print(raw[raw.index(b"Import-Name"):][:60])
print(email.parser.BytesParser().parsebytes(raw).defects)
```

```
b'Import-Name: flit_core\nflit_core\n---------\n\nThis provides a '
[MissingHeaderBodySeparatorDefect()]
```

`config.py` fills in `import_name` and `import_namespace` whenever the keys are absent from `[project]`, so this reaches every package built with 4.0.1 that has a description. Namespace packages fare worst, since the extra `Import-Namespace` fields concatenate onto the same line — a module named `a.b.c` emits `Import-Name: a.b.cImport-Namespace: aImport-Namespace: a.b`.

The existing `write_metadata_file` tests each exercise one field group at a time and none combine an `Import-*` field with a description, which is how this got through. The test added here covers that combination and fails on `main` with the concatenated line above.

Also reported in #813.

---
Drafted-by: Claude Code (Opus 5) (no human review before posting)
